### PR TITLE
Fixes possible crash on thread exit

### DIFF
--- a/java-spaghetti/src/vm.rs
+++ b/java-spaghetti/src/vm.rs
@@ -1,3 +1,4 @@
+use std::cell::{Cell, OnceCell};
 use std::ptr::null_mut;
 
 use jni_sys::*;
@@ -37,17 +38,57 @@ impl VM {
         F: for<'env> FnOnce(Env<'env>) -> R,
     {
         let mut env = null_mut();
-        match unsafe { ((**self.0).v1_2.GetEnv)(self.0, &mut env, JNI_VERSION_1_2) } {
-            JNI_OK => callback(unsafe { Env::from_raw(env as _) }),
-            JNI_EDETACHED => match unsafe { ((**self.0).v1_2.AttachCurrentThread)(self.0, &mut env, null_mut()) } {
-                JNI_OK => callback(unsafe { Env::from_raw(env as _) }),
-                unexpected => panic!("AttachCurrentThread returned unknown error: {}", unexpected),
-            },
+        let just_attached = match unsafe { ((**self.0).v1_2.GetEnv)(self.0, &mut env, JNI_VERSION_1_2) } {
+            JNI_OK => false,
+            JNI_EDETACHED => {
+                let ret = unsafe { ((**self.0).v1_2.AttachCurrentThread)(self.0, &mut env, null_mut()) };
+                if ret != JNI_OK {
+                    panic!("AttachCurrentThread returned unknown error: {}", ret)
+                }
+                if !get_thread_exit_flag() {
+                    set_thread_attach_flag(self.0);
+                }
+                true
+            }
             JNI_EVERSION => panic!("GetEnv returned JNI_EVERSION"),
             unexpected => panic!("GetEnv returned unknown error: {}", unexpected),
+        };
+
+        let result = callback(unsafe { Env::from_raw(env as _) });
+
+        if just_attached && get_thread_exit_flag() {
+            // this is needed in case of `with_env` is used on dropping some thread-local instance.
+            unsafe { ((**self.0).v1_2.DetachCurrentThread)(self.0) };
         }
+
+        result
     }
 }
 
 unsafe impl Send for VM {}
 unsafe impl Sync for VM {}
+
+thread_local! {
+    static THREAD_ATTACH_FLAG: Cell<Option<AttachFlag>> = const { Cell::new(None) };
+    static THREAD_EXIT_FLAG: OnceCell<()> = const { OnceCell::new() };
+}
+
+struct AttachFlag {
+    raw_vm: *mut JavaVM,
+}
+
+impl Drop for AttachFlag {
+    fn drop(&mut self) {
+        // avoids the fatal error "Native thread exiting without having called DetachCurrentThread"
+        unsafe { ((**self.raw_vm).v1_2.DetachCurrentThread)(self.raw_vm) };
+        let _ = THREAD_EXIT_FLAG.with(|flag| flag.set(()));
+    }
+}
+
+fn set_thread_attach_flag(raw_vm: *mut JavaVM) {
+    THREAD_ATTACH_FLAG.replace(Some(AttachFlag { raw_vm }));
+}
+
+fn get_thread_exit_flag() -> bool {
+    THREAD_EXIT_FLAG.with(|flag| flag.get().is_some())
+}


### PR DESCRIPTION
Fixes #2.

This brings an extra safety requirement for the unsafe `VM::from_raw(vm: *mut JavaVM)`: the caller has to make sure the provided `JavaVM` keeps valid throughout the application's lifetime (since the creation of the `VM`). This is not a problem on Android, though.

PS: I feel sorry for claiming about a soundness problem in `global.rs` that doesn't exist. I've deleted my wrong comment in 'https://github.com/Dirbaio/java-spaghetti/issues/1#issuecomment-2628345164'.

My test case for #2:

```toml
[package]
name = "java-spaghetti-test"
version = "0.1.0"
edition = "2021"
publish = false

[dependencies]
log = "0.4"
java-spaghetti = { path = "../java-spaghetti" }
android-activity = { version = "0.6", features = ["native-activity"] }
android_logger = "0.14"
ndk-context = "0.1.1"

[lib]
name = "java_spaghetti_test"
crate-type = ["cdylib"]
path = "lib.rs"

[package.metadata.android]
package = "com.example.android_simple_test"
build_targets = [ "aarch64-linux-android" ]

[package.metadata.android.sdk]
min_sdk_version = 16
target_sdk_version = 30
```

```rust
pub fn get_vm() -> java_spaghetti::VM {
    let vm = ndk_context::android_context().vm();
    if vm.is_null() {
        panic!("ndk-context is unconfigured: null JVM pointer, check the glue crate.");
    }
    unsafe { java_spaghetti::VM::from_raw(vm.cast()) }
}

#[no_mangle]
fn android_main(_: android_activity::AndroidApp) {
    android_logger::init_once(
        android_logger::Config::default()
            .with_max_level(log::LevelFilter::Info)
            .with_tag("java_spaghetti_test".as_bytes()),
    );
    let join_hdl = std::thread::spawn(|| {
        log::info!("background thread started...");
        let vm = get_vm();
        vm.with_env(|_env| {
            log::info!("enteres with_env...");
            log::info!("exits with_env...");
        });
        std::thread::sleep(std::time::Duration::from_secs(1));
        log::info!("background thread exits...");
    });
    join_hdl.join().unwrap();
    std::thread::sleep(std::time::Duration::from_secs(1));
    log::info!("android_main exits...");
}
```

The apk package can be built by `cargo apk` and installed on an Android phone.

Logcat snippet (before applying the fix):

```
02-01 17:37:14.656 12862 12877 I java_spaghetti_test: java_spaghetti_test: background thread exits...
02-01 17:37:14.656 12862 12877 W art     : Native thread exiting without having called DetachCurrentThread (maybe it's going to use a pthread_key_create destructor?): Thread[10,tid=12877,Native,Thread*=0x7f82f08200,peer=0x12d3a0a0,"Thread-352"]
02-01 17:37:14.656 12862 12877 F art     : art/runtime/thread.cc:1237] Native thread exited without calling DetachCurrentThread: Thread[10,tid=12877,Native,Thread*=0x7f82f08200,peer=0x12d3a0a0,"Thread-352"]
02-01 17:37:14.656 12862 12875 I RustStdoutStderr: referenceTable GDEF length=814 1
02-01 17:37:14.656 12862 12875 I RustStdoutStderr: referenceTable GSUB length=11364 1
02-01 17:37:14.656 12862 12875 I RustStdoutStderr: referenceTable GPOS length=47302 1
--------- beginning of crash
02-01 17:37:14.673 12862 12877 F libc    : Fatal signal 11 (SIGSEGV), code 1, fault addr 0xb8 in tid 12877 (Thread-352)
```

After applying the fix:

```
02-01 17:35:18.858 12627 12644 I java_spaghetti_test: java_spaghetti_test: background thread started...
02-01 17:35:18.859 12627 12644 I java_spaghetti_test: java_spaghetti_test: enteres with_env...
02-01 17:35:18.859 12627 12644 I java_spaghetti_test: java_spaghetti_test: exits with_env...
02-01 17:35:19.859 12627 12644 I java_spaghetti_test: java_spaghetti_test: background thread exits...
02-01 17:35:20.859 12627 12643 I java_spaghetti_test: java_spaghetti_test: android_main exits...
```
