### PR TITLE
Port java-spaghetti-gen to cafebabe; cache method/field IDs; fix jclass memory leaks

### DIFF
--- a/.github/workflows/rust_nightly.yml
+++ b/.github/workflows/rust_nightly.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Rust - Nightly
 
 on:
   push:
@@ -11,10 +11,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build_and_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - run: rustup update nightly && rustup default nightly
+    - run: rustup component add rustfmt
     - name: Check fmt
       run: cargo fmt -- --check
     - name: Test

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The full list of differences are:
 - You can filter which classes are generated in the TOML config.
 - Generated code uses relative paths (`super::...`) instead of absolute paths (`crate::...`), so it works if you place it in a submodule not at the crate root.
 - Generated code is a single `.rs` file, there's no support for spltting it in one file per class. You can still run the output through [form](https://github.com/djmcgill/form), if you want.
+- Generated code uses cached method IDs and field IDs stored in `OnceLock` to speed up invocations by several times. Used classes are also stored as JNI global references in order to keep the validity of cached IDs. This may not ensure memory safety when class redefinition features (e.g. `java.lang.instrument` which is unavailable on Android) of the JVM is being used.
 - Generated code doesn't use macros.
 - No support for generating Cargo features per class.
 - Modernized rust, updated dependencies.

--- a/java-spaghetti-gen/Cargo.toml
+++ b/java-spaghetti-gen/Cargo.toml
@@ -9,13 +9,13 @@ categories = ["development-tools::ffi"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-jreflection             = "0.0.11"
-clap                    = { version = "4", features = ["derive"] }
-bitflags                = "2.4.2"
-serde                   = "1.0.197"
-serde_derive            = "1.0.197"
-toml                    = "0.8.10"
-zip                     = "0.6.6"
+cafebabe = "0.8.0"
+clap = { version = "4", features = ["derive"] }
+bitflags = "2.8.0"
+serde = "1.0.197"
+serde_derive = "1.0.197"
+toml = "0.8.10"
+zip = "2.2.2"
 
 [dev-dependencies]
-jni-sys                 = "0.4.0"
+jni-sys  = "0.4.0"

--- a/java-spaghetti-gen/src/emit_rust/context.rs
+++ b/java-spaghetti-gen/src/emit_rust/context.rs
@@ -5,12 +5,10 @@ use std::rc::Rc;
 use std::sync::Mutex;
 use std::time::Duration;
 
-use jreflection::class;
-
 use super::modules::Module;
 use super::preamble::write_preamble;
 use super::structs::Struct;
-use crate::{config, util};
+use crate::{config, parser_util, util};
 
 pub struct Context<'a> {
     pub(crate) config: &'a config::runtime::Config,
@@ -32,10 +30,11 @@ impl<'a> Context<'a> {
     }
 
     pub(crate) fn throwable_rust_path(&self, mod_: &str) -> String {
-        self.java_to_rust_path(class::Id("java/lang/Throwable"), mod_).unwrap()
+        self.java_to_rust_path(parser_util::Id("java/lang/Throwable"), mod_)
+            .unwrap()
     }
 
-    pub fn java_to_rust_path(&self, java_class: class::Id, mod_: &str) -> Result<String, Box<dyn Error>> {
+    pub fn java_to_rust_path(&self, java_class: parser_util::Id, mod_: &str) -> Result<String, Box<dyn Error>> {
         let m = Struct::mod_for(self, java_class)?;
         let s = Struct::name_for(self, java_class)?;
         let fqn = format!("{}::{}", m, s);
@@ -92,18 +91,18 @@ impl<'a> Context<'a> {
             pat.pop();
         }
 
-        return false;
+        false
     }
 
-    pub fn add_struct(&mut self, class: jreflection::Class) -> Result<(), Box<dyn Error>> {
-        if self.config.ignore_classes.contains(class.path.as_str()) {
+    pub fn add_struct(&mut self, class: parser_util::Class) -> Result<(), Box<dyn Error>> {
+        if self.config.ignore_classes.contains(class.path().as_str()) {
             return Ok(());
         }
-        if !self.struct_included(class.path.as_str()) {
+        if !self.struct_included(class.path().as_str()) {
             return Ok(());
         }
 
-        let java_path = class.path.as_str().to_string();
+        let java_path = class.path().as_str().to_string();
         let s = Rc::new(Struct::new(self, class)?);
 
         self.all_classes.insert(java_path, s.clone());

--- a/java-spaghetti-gen/src/emit_rust/fields.rs
+++ b/java-spaghetti-gen/src/emit_rust/fields.rs
@@ -129,7 +129,7 @@ impl<'a> Field<'a> {
                 match descriptor.field_type {
                     FieldType::Char if descriptor.dimensions == 0 => writeln!(
                         out,
-                        "{indent}{attributes}pub const {constant} : {rust_get_type} = {rust_get_type}({value_writer});",
+                        "{indent}{attributes}pub const {constant} : u16 = {value_writer}u16;",
                     )?,
                     FieldType::Boolean if descriptor.dimensions == 0 => writeln!(
                         out,

--- a/java-spaghetti-gen/src/emit_rust/fields.rs
+++ b/java-spaghetti-gen/src/emit_rust/fields.rs
@@ -159,7 +159,8 @@ impl<'a> Field<'a> {
                 )?;
                 writeln!(
                     out,
-                    "{indent}    static __FIELD: ::std::sync::OnceLock<usize> = ::std::sync::OnceLock::new();"
+                    "{indent}    static __FIELD: ::std::sync::OnceLock<::java_spaghetti::JFieldID> \
+                        = ::std::sync::OnceLock::new();"
                 )?;
                 writeln!(out, "{indent}    unsafe {{")?;
                 if !self.java.is_static() {
@@ -172,9 +173,9 @@ impl<'a> Field<'a> {
                 writeln!(
                     out,
                     "{indent}        \
-                    let __jni_field = *__FIELD.get_or_init(|| \
-                        __jni_env.require_{}field(__jni_class, {}, {}).addr()\
-                    ) as ::java_spaghetti::sys::jfieldID;",
+                    let __jni_field = __FIELD.get_or_init(|| \
+                        ::java_spaghetti::JFieldID::from_raw(__jni_env.require_{}field(__jni_class, {}, {}))\
+                    ).as_raw();",
                     if self.java.is_static() { "static_" } else { "" },
                     StrEmitter(self.java.name()),
                     StrEmitter(FieldSigWriter(self.java.descriptor()))
@@ -213,7 +214,8 @@ impl<'a> Field<'a> {
                     )?;
                     writeln!(
                         out,
-                        "{indent}    static __FIELD: ::std::sync::OnceLock<usize> = ::std::sync::OnceLock::new();"
+                        "{indent}    static __FIELD: ::std::sync::OnceLock<::java_spaghetti::JFieldID> \
+                            = ::std::sync::OnceLock::new();"
                     )?;
                     writeln!(out, "{indent}    unsafe {{")?;
                     if !self.java.is_static() {
@@ -226,9 +228,9 @@ impl<'a> Field<'a> {
                     writeln!(
                         out,
                         "{indent}        \
-                        let __jni_field = *__FIELD.get_or_init(|| \
-                            __jni_env.require_{}field(__jni_class, {}, {}).addr()\
-                        ) as ::java_spaghetti::sys::jfieldID;",
+                        let __jni_field = __FIELD.get_or_init(|| \
+                            ::java_spaghetti::JFieldID::from_raw(__jni_env.require_{}field(__jni_class, {}, {}))\
+                        ).as_raw();",
                         if self.java.is_static() { "static_" } else { "" },
                         StrEmitter(self.java.name()),
                         StrEmitter(FieldSigWriter(self.java.descriptor()))

--- a/java-spaghetti-gen/src/emit_rust/fields.rs
+++ b/java-spaghetti-gen/src/emit_rust/fields.rs
@@ -1,21 +1,26 @@
+use std::borrow::Cow;
+use std::fmt::Write;
 use std::io;
 
-use jreflection::{class, field};
+use cafebabe::constant_pool::LiteralConstant;
+use cafebabe::descriptors::{FieldDescriptor, FieldType};
 
 use super::known_docs_url::KnownDocsUrl;
+use super::StrEmitter;
 use crate::emit_rust::Context;
 use crate::identifiers::{FieldMangling, IdentifierManglingError};
+use crate::parser_util::{Class, ClassName, FieldSigWriter, IdBuf, IterableId, JavaField};
 
 pub struct Field<'a> {
-    pub class: &'a jreflection::Class,
-    pub java: &'a jreflection::Field,
+    pub class: &'a Class,
+    pub java: JavaField<'a>,
     pub rust_names: Result<FieldMangling<'a>, IdentifierManglingError>,
     pub ignored: bool,
 }
 
 impl<'a> Field<'a> {
-    pub fn new(context: &Context, class: &'a jreflection::Class, java: &'a jreflection::Field) -> Self {
-        let java_class_field = format!("{}\x1f{}", class.path.as_str(), &java.name);
+    pub fn new(context: &Context, class: &'a Class, java: &'a cafebabe::FieldInfo<'a>) -> Self {
+        let java_class_field = format!("{}\x1f{}", class.path().as_str(), &java.name);
         let ignored = context.config.ignore_class_fields.contains(&java_class_field);
         let renamed_to = context
             .config
@@ -23,13 +28,16 @@ impl<'a> Field<'a> {
             .get(&java_class_field)
             .map(|s| s.as_str());
 
-        let result = Self {
+        Self {
             class,
-            java,
-            rust_names: context.config.codegen.field_naming_style.mangle(java, renamed_to),
+            java: JavaField::from(java),
+            rust_names: context
+                .config
+                .codegen
+                .field_naming_style
+                .mangle(JavaField::from(java), renamed_to),
             ignored,
-        };
-        result
+        }
     }
 
     pub fn emit(&self, context: &Context, mod_: &str, out: &mut impl io::Write) -> io::Result<()> {
@@ -42,107 +50,31 @@ impl<'a> Field<'a> {
             emit_reject_reasons.push("[[ignore]]d");
         }
 
-        let descriptor = self.java.descriptor();
-        let rust_set_type_buffer;
-        let rust_get_type_buffer;
-        let (rust_set_type, rust_get_type) = match descriptor {
-            field::Descriptor::Single(field::BasicType::Boolean) => ("bool", "bool"),
-            field::Descriptor::Single(field::BasicType::Byte) => ("i8", "i8"),
-            field::Descriptor::Single(field::BasicType::Char) => ("u16", "u16"),
-            field::Descriptor::Single(field::BasicType::Double) => ("f64", "f64"),
-            field::Descriptor::Single(field::BasicType::Float) => ("f32", "f32"),
-            field::Descriptor::Single(field::BasicType::Int) => ("i32", "i32"),
-            field::Descriptor::Single(field::BasicType::Long) => ("i64", "i64"),
-            field::Descriptor::Single(field::BasicType::Short) => ("i16", "i16"),
-            field::Descriptor::Single(field::BasicType::Class(class::Id("java/lang/String")))
-                if self.java.is_constant() =>
-            {
+        let descriptor = &self.java.descriptor();
+        let type_emitter = FieldTypeEmitter(descriptor);
+
+        let rust_type = type_emitter
+            .emit_rust_type(context, mod_, &mut emit_reject_reasons)
+            .map_err(|_| io::Error::other("std::fmt::Error"))?;
+
+        let (rust_set_type_buffer, rust_get_type_buffer);
+        // `rust_set_type` and `rust_get_type` are ones used below
+        let (rust_set_type, rust_get_type) = match (descriptor.dimensions, &descriptor.field_type) {
+            (0, t) if !matches!(t, FieldType::Object(_)) => (rust_type.as_ref(), rust_type.as_ref()),
+            (0, FieldType::Object(cls)) if self.java.is_constant() && ClassName::from(cls).is_string_class() => {
                 ("&'static str", "&'static str")
             }
-            field::Descriptor::Single(field::BasicType::Void) => {
-                emit_reject_reasons.push("ERROR:  void is not a valid field type");
-                ("()", "()")
-            }
-            field::Descriptor::Single(field::BasicType::Class(class)) => {
-                if !context.all_classes.contains_key(class.as_str()) {
-                    emit_reject_reasons.push("ERROR:  missing class for field type");
-                }
-                if let Ok(fqn) = context.java_to_rust_path(class, mod_) {
-                    rust_set_type_buffer = format!("impl ::java_spaghetti::AsArg<{}>", &fqn);
-                    rust_get_type_buffer = format!("::std::option::Option<::java_spaghetti::Local<'env, {}>>", &fqn);
-                    (rust_set_type_buffer.as_str(), rust_get_type_buffer.as_str())
-                } else {
-                    emit_reject_reasons.push("ERROR:  Unable to resolve class FQN");
-                    ("???", "???")
-                }
-            }
-            field::Descriptor::Array { levels, inner } => {
-                let mut buffer = String::new();
-                for _ in 0..(levels - 1) {
-                    buffer.push_str("::java_spaghetti::ObjectArray<");
-                }
-                match inner {
-                    field::BasicType::Boolean => buffer.push_str("::java_spaghetti::BooleanArray"),
-                    field::BasicType::Byte => buffer.push_str("::java_spaghetti::ByteArray"),
-                    field::BasicType::Char => buffer.push_str("::java_spaghetti::CharArray"),
-                    field::BasicType::Short => buffer.push_str("::java_spaghetti::ShortArray"),
-                    field::BasicType::Int => buffer.push_str("::java_spaghetti::IntArray"),
-                    field::BasicType::Long => buffer.push_str("::java_spaghetti::LongArray"),
-                    field::BasicType::Float => buffer.push_str("::java_spaghetti::FloatArray"),
-                    field::BasicType::Double => buffer.push_str("::java_spaghetti::DoubleArray"),
-                    field::BasicType::Class(class) => {
-                        if !context.all_classes.contains_key(class.as_str()) {
-                            emit_reject_reasons.push("ERROR:  missing class for field type");
-                        }
-
-                        buffer.push_str("::java_spaghetti::ObjectArray<");
-                        match context.java_to_rust_path(class, mod_) {
-                            Ok(path) => buffer.push_str(path.as_str()),
-                            Err(_) => {
-                                emit_reject_reasons
-                                    .push("ERROR:  Failed to resolve JNI path to Rust path for argument type");
-                                buffer.push_str("???");
-                            }
-                        }
-                        buffer.push_str(", ");
-                        buffer.push_str(&context.throwable_rust_path(mod_));
-                        buffer.push('>');
-                    }
-                    field::BasicType::Void => {
-                        emit_reject_reasons.push("ERROR:  Arrays of void isn't a thing");
-                        buffer.push_str("[()]");
-                    }
-                }
-                for _ in 0..(levels - 1) {
-                    // ObjectArray s
-                    buffer.push_str(", ");
-                    buffer.push_str(&context.throwable_rust_path(mod_));
-                    buffer.push('>');
-                }
-
-                rust_set_type_buffer = format!("impl ::java_spaghetti::AsArg<{}>", &buffer);
-                rust_get_type_buffer = format!("::std::option::Option<::java_spaghetti::Local<'env, {}>>", &buffer);
+            _ => {
+                rust_set_type_buffer = format!("impl ::java_spaghetti::AsArg<{}>", &rust_type);
+                rust_get_type_buffer = format!("::std::option::Option<::java_spaghetti::Local<'env, {}>>", &rust_type);
                 (rust_set_type_buffer.as_str(), rust_get_type_buffer.as_str())
             }
         };
 
-        let field_fragment = match self.java.descriptor() {
-            // Contents of {get,set}_[static_]..._field
-            field::Descriptor::Single(field::BasicType::Void) => "void",
-            field::Descriptor::Single(field::BasicType::Boolean) => "boolean",
-            field::Descriptor::Single(field::BasicType::Byte) => "byte",
-            field::Descriptor::Single(field::BasicType::Char) => "char",
-            field::Descriptor::Single(field::BasicType::Short) => "short",
-            field::Descriptor::Single(field::BasicType::Int) => "int",
-            field::Descriptor::Single(field::BasicType::Long) => "long",
-            field::Descriptor::Single(field::BasicType::Float) => "float",
-            field::Descriptor::Single(field::BasicType::Double) => "double",
-            field::Descriptor::Single(field::BasicType::Class(_)) => "object",
-            field::Descriptor::Array { .. } => "object",
-        };
+        let field_fragment = type_emitter.emit_fragment_type();
 
         if self.rust_names.is_err() {
-            emit_reject_reasons.push(match self.java.name.as_str() {
+            emit_reject_reasons.push(match self.java.name() {
                 "$VALUES" => "Failed to mangle field name: enum $VALUES", // Expected
                 s if s.starts_with("this$") => "Failed to mangle field name: this$N outer class pointer", // Expected
                 _ => "ERROR:  Failed to mangle field name(s)",
@@ -167,7 +99,7 @@ impl<'a> Field<'a> {
             if self.java.is_volatile() { " volatile" } else { "" }
         );
 
-        let attributes = (if self.java.deprecated { "#[deprecated] " } else { "" }).to_string();
+        let attributes = if self.java.deprecated() { "#[deprecated] " } else { "" };
 
         writeln!(out)?;
         for reason in &emit_reject_reasons {
@@ -182,32 +114,27 @@ impl<'a> Field<'a> {
 
         let url = KnownDocsUrl::from_field(
             context,
-            self.class.path.as_str(),
-            self.java.name.as_str(),
-            self.java.descriptor(),
+            self.class.path().as_str(),
+            self.java.name(),
+            self.java.descriptor().clone(),
         );
         let url = url.as_ref();
 
         match self.rust_names.as_ref() {
             Ok(FieldMangling::ConstValue(constant, value)) => {
-                let value = *value;
+                let value_writer = ConstantWriter(value);
                 if let Some(url) = url {
-                    writeln!(out, "{}/// {} {}", indent, &keywords, url)?;
+                    writeln!(out, "{indent}/// {keywords} {url}")?;
                 }
-                match descriptor {
-                    field::Descriptor::Single(field::BasicType::Char) => writeln!(
+                match descriptor.field_type {
+                    FieldType::Char if descriptor.dimensions == 0 => writeln!(
                         out,
-                        "{}{}pub const {} : {} = {}({});",
-                        indent, &attributes, constant, rust_get_type, rust_get_type, value
+                        "{indent}{attributes}pub const {constant} : {rust_get_type} = {rust_get_type}({value_writer});",
                     )?,
-                    field::Descriptor::Single(field::BasicType::Boolean) => writeln!(
+                    FieldType::Boolean if descriptor.dimensions == 0 => writeln!(
                         out,
-                        "{}{}pub const {} : {} = {};",
-                        indent,
-                        &attributes,
-                        constant,
-                        rust_get_type,
-                        if value == &field::Constant::Integer(0) {
+                        "{indent}{attributes}pub const {constant} : {rust_get_type} = {};",
+                        if let LiteralConstant::Integer(0) = value {
                             "false"
                         } else {
                             "true"
@@ -215,51 +142,47 @@ impl<'a> Field<'a> {
                     )?,
                     _ => writeln!(
                         out,
-                        "{}{}pub const {} : {} = {};",
-                        indent, &attributes, constant, rust_get_type, value
+                        "{indent}{attributes}pub const {constant} : {rust_get_type} = {value_writer};",
                     )?,
                 }
             }
             Ok(FieldMangling::GetSet(get, set)) => {
                 // Getter
                 if let Some(url) = url {
-                    writeln!(out, "{}/// **get** {} {}", indent, &keywords, url)?;
+                    writeln!(out, "{indent}/// **get** {keywords} {url}")?;
                 } else {
-                    writeln!(out, "{}/// **get** {} {}", indent, &keywords, self.java.name.as_str())?;
+                    writeln!(out, "{indent}/// **get** {keywords} {}", self.java.name())?;
                 }
                 writeln!(
                     out,
-                    "{}{}pub fn {}<'env>({}) -> {} {{",
-                    indent, &attributes, get, env_param, rust_get_type
+                    "{indent}{attributes}pub fn {get}<'env>({env_param}) -> {rust_get_type} {{",
                 )?;
-                writeln!(out, "{}    unsafe {{", indent)?;
+                writeln!(out, "{indent}    unsafe {{")?;
                 if !self.java.is_static() {
-                    writeln!(out, "{}        let env = self.env();", indent)?;
+                    writeln!(out, "{indent}        let env = self.env();")?;
                 }
                 writeln!(
                     out,
                     "{}        let (__jni_class, __jni_field) = env.require_class_{}field({}, {}, {});",
                     indent,
                     if self.java.is_static() { "static_" } else { "" },
-                    emit_cstr(self.class.path.as_str()),
-                    emit_cstr(self.java.name.as_str()),
-                    emit_cstr(self.java.descriptor_str())
+                    StrEmitter(self.class.path().as_str()),
+                    StrEmitter(self.java.name()),
+                    StrEmitter(FieldSigWriter(self.java.descriptor()))
                 )?;
                 if self.java.is_static() {
                     writeln!(
                         out,
-                        "{}        env.get_static_{}_field(__jni_class, __jni_field)",
-                        indent, field_fragment
+                        "{indent}        env.get_static_{field_fragment}_field(__jni_class, __jni_field)",
                     )?;
                 } else {
                     writeln!(
                         out,
-                        "{}        env.get_{}_field(self.as_raw(), __jni_field)",
-                        indent, field_fragment
+                        "{indent}        env.get_{field_fragment}_field(self.as_raw(), __jni_field)",
                     )?;
                 }
-                writeln!(out, "{}    }}", indent)?;
-                writeln!(out, "{}}}", indent)?;
+                writeln!(out, "{indent}    }}")?;
+                writeln!(out, "{indent}}}")?;
 
                 // Setter
                 if !self.java.is_final() {
@@ -271,64 +194,53 @@ impl<'a> Field<'a> {
 
                     writeln!(out)?;
                     if let Some(url) = url {
-                        writeln!(out, "{}/// **set** {} {}", indent, &keywords, url)?;
+                        writeln!(out, "{indent}/// **set** {keywords} {url}")?;
                     } else {
-                        writeln!(out, "{}/// **set** {} {}", indent, &keywords, self.java.name.as_str())?;
+                        writeln!(out, "{indent}/// **set** {keywords} {}", self.java.name())?;
                     }
                     writeln!(
                         out,
-                        "{}{}pub fn {}<{}>({}, value: {}) {{",
-                        indent, &attributes, set, lifetimes, env_param, rust_set_type
+                        "{indent}{attributes}pub fn {set}<{lifetimes}>({env_param}, value: {rust_set_type}) {{",
                     )?;
-                    writeln!(out, "{}    unsafe {{", indent)?;
+                    writeln!(out, "{indent}    unsafe {{")?;
                     if !self.java.is_static() {
-                        writeln!(out, "{}        let env = self.env();", indent)?;
+                        writeln!(out, "{indent}        let env = self.env();")?;
                     }
                     writeln!(
                         out,
                         "{}        let (__jni_class, __jni_field) = env.require_class_{}field({}, {}, {});",
                         indent,
                         if self.java.is_static() { "static_" } else { "" },
-                        emit_cstr(self.class.path.as_str()),
-                        emit_cstr(self.java.name.as_str()),
-                        emit_cstr(self.java.descriptor_str())
+                        StrEmitter(self.class.path().as_str()),
+                        StrEmitter(self.java.name()),
+                        StrEmitter(FieldSigWriter(self.java.descriptor()))
                     )?;
                     if self.java.is_static() {
                         writeln!(
                             out,
-                            "{}        env.set_static_{}_field(__jni_class, __jni_field, value)",
-                            indent, field_fragment
+                            "{indent}        env.set_static_{field_fragment}_field(__jni_class, __jni_field, value)",
                         )?;
                     } else {
                         writeln!(
                             out,
-                            "{}        env.set_{}_field(self.as_raw(), __jni_field, value)",
-                            indent, field_fragment
+                            "{indent}        env.set_{field_fragment}_field(self.as_raw(), __jni_field, value)",
                         )?;
                     }
-                    writeln!(out, "{}    }}", indent)?;
-                    writeln!(out, "{}}}", indent)?;
+                    writeln!(out, "{indent}    }}")?;
+                    writeln!(out, "{indent}}}")?;
                 }
             }
             Err(_) => {
                 writeln!(
                     out,
-                    "{}{}pub fn get_{:?}<'env>({}) -> {} {{ ... }}",
-                    indent,
-                    &attributes,
-                    self.java.name.as_str(),
-                    env_param,
-                    rust_get_type
+                    "{indent}{attributes}pub fn get_{:?}<'env>({env_param}) -> {rust_get_type} {{ ... }}",
+                    self.java.name(),
                 )?;
                 if !self.java.is_final() {
                     writeln!(
                         out,
-                        "{}{}pub fn set_{:?}<'env>({}) -> {} {{ ... }}",
-                        indent,
-                        &attributes,
-                        self.java.name.as_str(),
-                        env_param,
-                        rust_set_type
+                        "{indent}{attributes}pub fn set_{:?}<'env>({env_param}) -> {rust_set_type} {{ ... }}",
+                        self.java.name(),
                     )?;
                 }
             }
@@ -338,8 +250,135 @@ impl<'a> Field<'a> {
     }
 }
 
-fn emit_cstr(s: &str) -> String {
-    let mut s = format!("{:?}", s); // XXX
-    s.insert_str(s.len() - 1, "\\0");
-    s
+struct ConstantWriter<'a>(&'a LiteralConstant<'a>);
+
+// Migrated from <https://docs.rs/jreflection/latest/src/jreflection/field.rs.html#53-73>,
+// which seems like a bug for `java-spaghetti`.
+impl std::fmt::Display for ConstantWriter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            LiteralConstant::Integer(value) => write!(f, "{}", value),
+            LiteralConstant::Long(value) => write!(f, "{}i64", value),
+
+            LiteralConstant::Float(value) if value.is_infinite() && *value < 0.0 => {
+                write!(f, "::std::f32::NEG_INFINITY")
+            }
+            LiteralConstant::Float(value) if value.is_infinite() => write!(f, "::std::f32::INFINITY"),
+            LiteralConstant::Float(value) if value.is_nan() => write!(f, "::std::f32::NAN"),
+            LiteralConstant::Float(value) => write!(f, "{}f32", value),
+
+            LiteralConstant::Double(value) if value.is_infinite() && *value < 0.0 => {
+                write!(f, "::std::f64::NEG_INFINITY")
+            }
+            LiteralConstant::Double(value) if value.is_infinite() => write!(f, "::std::f64::INFINITY"),
+            LiteralConstant::Double(value) if value.is_nan() => write!(f, "::std::f64::NAN"),
+            LiteralConstant::Double(value) => write!(f, "{}f64", value),
+
+            LiteralConstant::String(value) => std::fmt::Debug::fmt(value, f),
+            LiteralConstant::StringBytes(_) => {
+                write!(f, "panic!(\"Java string constant contains invalid 'Modified UTF8'\")")
+            }
+        }
+    }
+}
+
+pub struct FieldTypeEmitter<'a>(pub &'a FieldDescriptor<'a>);
+
+impl FieldTypeEmitter<'_> {
+    /// Generates the corresponding Rust type for the Java field type.
+    pub fn emit_rust_type(
+        &self,
+        context: &Context<'_>,
+        mod_: &str,
+        reject_reasons: &mut Vec<&'static str>,
+    ) -> Result<Cow<'static, str>, std::fmt::Error> {
+        use Cow::Borrowed;
+        let descriptor = self.0;
+        let cow = if descriptor.dimensions == 0 {
+            match &descriptor.field_type {
+                FieldType::Boolean => Borrowed("bool"),
+                FieldType::Byte => Borrowed("i8"),
+                FieldType::Char => Borrowed("u16"),
+                FieldType::Short => Borrowed("i16"),
+                FieldType::Integer => Borrowed("i32"),
+                FieldType::Long => Borrowed("i64"),
+                FieldType::Float => Borrowed("f32"),
+                FieldType::Double => Borrowed("f64"),
+                FieldType::Object(class_name) => {
+                    let class = IdBuf::from(class_name);
+                    if !context.all_classes.contains_key(class.as_str()) {
+                        reject_reasons.push("ERROR:  missing class for field/argument type");
+                    }
+                    if let Ok(path) = context.java_to_rust_path(class.as_id(), mod_) {
+                        path
+                    } else {
+                        reject_reasons.push("ERROR:  Failed to resolve JNI path to Rust path for class type");
+                        format!("{:?}", class) // XXX
+                    }
+                    .into()
+                }
+            }
+        } else {
+            let mut out = String::new();
+            for _ in 0..(descriptor.dimensions - 1) {
+                write!(out, "::java_spaghetti::ObjectArray<")?;
+            }
+            match &descriptor.field_type {
+                FieldType::Boolean => write!(out, "::java_spaghetti::BooleanArray"),
+                FieldType::Byte => write!(out, "::java_spaghetti::ByteArray"),
+                FieldType::Char => write!(out, "::java_spaghetti::CharArray"),
+                FieldType::Short => write!(out, "::java_spaghetti::ShortArray"),
+                FieldType::Integer => write!(out, "::java_spaghetti::IntArray"),
+                FieldType::Long => write!(out, "::java_spaghetti::LongArray"),
+                FieldType::Float => write!(out, "::java_spaghetti::FloatArray"),
+                FieldType::Double => write!(out, "::java_spaghetti::DoubleArray"),
+                FieldType::Object(class_name) => {
+                    let class = IdBuf::from(class_name);
+
+                    if !context.all_classes.contains_key(class.as_str()) {
+                        reject_reasons.push("ERROR:  missing class for field type");
+                    }
+
+                    write!(out, "::java_spaghetti::ObjectArray<")?;
+                    match context.java_to_rust_path(class.as_id(), mod_) {
+                        Ok(path) => write!(out, "{path}"),
+                        Err(_) => {
+                            reject_reasons.push("ERROR:  Failed to resolve JNI path to Rust path for class type");
+                            write!(out, "???")
+                        }
+                    }?;
+                    write!(out, ", ")?;
+                    write!(out, "{}", &context.throwable_rust_path(mod_))?;
+                    write!(out, ">")
+                }
+            }?;
+            for _ in 0..(descriptor.dimensions - 1) {
+                // ObjectArray s
+                write!(out, ", ")?;
+                write!(out, "{}", &context.throwable_rust_path(mod_))?;
+                write!(out, ">")?;
+            }
+            out.into()
+        };
+        Ok(cow)
+    }
+
+    /// Contents of {get,set}_[static_]..._field, call_..._method_a.
+    pub fn emit_fragment_type(&self) -> &'static str {
+        if self.0.dimensions == 0 {
+            match self.0.field_type {
+                FieldType::Boolean => "boolean",
+                FieldType::Byte => "byte",
+                FieldType::Char => "char",
+                FieldType::Short => "short",
+                FieldType::Integer => "int",
+                FieldType::Long => "long",
+                FieldType::Float => "float",
+                FieldType::Double => "double",
+                FieldType::Object(_) => "object",
+            }
+        } else {
+            "object"
+        }
+    }
 }

--- a/java-spaghetti-gen/src/emit_rust/known_docs_url.rs
+++ b/java-spaghetti-gen/src/emit_rust/known_docs_url.rs
@@ -1,9 +1,10 @@
 use std::fmt::{self, Display, Formatter};
 
-use jreflection::{field, method};
+use cafebabe::descriptors::{FieldDescriptor, FieldType};
 
 use super::methods::Method;
 use crate::emit_rust::Context;
+use crate::parser_util::{Id, IdBuf};
 
 pub(crate) struct KnownDocsUrl {
     pub(crate) label: String,
@@ -17,7 +18,7 @@ impl Display for KnownDocsUrl {
 }
 
 impl KnownDocsUrl {
-    pub(crate) fn from_class(context: &Context, java_class: jreflection::class::Id) -> Option<KnownDocsUrl> {
+    pub(crate) fn from_class(context: &Context, java_class: Id) -> Option<KnownDocsUrl> {
         let java_class = java_class.as_str();
         let pattern = context
             .config
@@ -35,7 +36,7 @@ impl KnownDocsUrl {
             }
         }
 
-        let last_slash = java_class.rfind(|ch| ch == '/');
+        let last_slash = java_class.rfind('/');
         let no_namespace = if let Some(last_slash) = last_slash {
             &java_class[(last_slash + 1)..]
         } else {
@@ -56,15 +57,13 @@ impl KnownDocsUrl {
     }
 
     pub(crate) fn from_method(context: &Context, method: &Method) -> Option<KnownDocsUrl> {
-        use method::{BasicType, Type};
-
         let is_constructor = method.java.is_constructor();
 
         let pattern = context
             .config
             .doc_patterns
             .iter()
-            .find(|pattern| method.class.path.as_str().starts_with(pattern.jni_prefix.as_str()))?;
+            .find(|pattern| method.class.path().as_str().starts_with(pattern.jni_prefix.as_str()))?;
         let url_pattern = if is_constructor {
             pattern
                 .constructor_url_pattern
@@ -74,7 +73,7 @@ impl KnownDocsUrl {
             pattern.method_url_pattern.as_ref()?
         };
 
-        for ch in method.class.path.as_str().chars() {
+        for ch in method.class.path().as_str().chars() {
             match ch {
                 'a'..='z' => {}
                 'A'..='Z' => {}
@@ -86,14 +85,14 @@ impl KnownDocsUrl {
 
         let java_class = method
             .class
-            .path
+            .path()
             .as_str()
             .replace('/', pattern.class_namespace_separator.as_str())
             .replace('$', pattern.class_inner_class_seperator.as_str());
 
         let java_outer_class = method
             .class
-            .path
+            .path()
             .as_str()
             .rsplit('/')
             .next()
@@ -102,7 +101,7 @@ impl KnownDocsUrl {
 
         let java_inner_class = method
             .class
-            .path
+            .path()
             .as_str()
             .rsplit('/')
             .next()
@@ -114,7 +113,7 @@ impl KnownDocsUrl {
         let label = if is_constructor {
             java_inner_class
         } else {
-            for ch in method.java.name.as_str().chars() {
+            for ch in method.java.name().chars() {
                 match ch {
                     'a'..='z' => {}
                     'A'..='Z' => {}
@@ -123,13 +122,13 @@ impl KnownDocsUrl {
                     _ch => return None,
                 }
             }
-            method.java.name.as_str()
+            method.java.name()
         };
 
         let mut java_args = String::new();
 
         let mut prev_was_array = false;
-        for arg in method.java.descriptor().arguments() {
+        for arg in method.java.descriptor().parameters.iter() {
             if prev_was_array {
                 prev_was_array = false;
                 java_args.push_str("%5B%5D"); // []
@@ -139,67 +138,30 @@ impl KnownDocsUrl {
                 java_args.push_str(&pattern.argument_seperator[..]);
             }
 
-            match arg {
-                Type::Single(BasicType::Void) => {
-                    java_args.push_str("void");
-                }
-                Type::Single(BasicType::Boolean) => {
-                    java_args.push_str("boolean");
-                }
-                Type::Single(BasicType::Byte) => {
-                    java_args.push_str("byte");
-                }
-                Type::Single(BasicType::Char) => {
-                    java_args.push_str("char");
-                }
-                Type::Single(BasicType::Short) => {
-                    java_args.push_str("short");
-                }
-                Type::Single(BasicType::Int) => {
-                    java_args.push_str("int");
-                }
-                Type::Single(BasicType::Long) => {
-                    java_args.push_str("long");
-                }
-                Type::Single(BasicType::Float) => {
-                    java_args.push_str("float");
-                }
-                Type::Single(BasicType::Double) => {
-                    java_args.push_str("double");
-                }
-                Type::Single(BasicType::Class(class)) => {
-                    let class = class
+            let obj_arg;
+            java_args.push_str(match arg.field_type {
+                FieldType::Boolean => "boolean",
+                FieldType::Byte => "byte",
+                FieldType::Char => "char",
+                FieldType::Short => "short",
+                FieldType::Integer => "int",
+                FieldType::Long => "long",
+                FieldType::Float => "float",
+                FieldType::Double => "double",
+                FieldType::Object(ref class_name) => {
+                    let class = IdBuf::from(class_name);
+                    obj_arg = class
                         .as_str()
                         .replace('/', pattern.argument_namespace_separator.as_str())
                         .replace('$', pattern.argument_inner_class_seperator.as_str());
-                    java_args.push_str(&class);
+                    obj_arg.as_str()
                 }
-                Type::Array { levels, inner } => {
-                    match inner {
-                        BasicType::Void => {
-                            return None;
-                        }
-                        BasicType::Boolean => java_args.push_str("bool"),
-                        BasicType::Byte => java_args.push_str("byte"),
-                        BasicType::Char => java_args.push_str("char"),
-                        BasicType::Short => java_args.push_str("short"),
-                        BasicType::Int => java_args.push_str("int"),
-                        BasicType::Long => java_args.push_str("long"),
-                        BasicType::Float => java_args.push_str("float"),
-                        BasicType::Double => java_args.push_str("double"),
-                        BasicType::Class(class) => {
-                            let class = class
-                                .as_str()
-                                .replace('/', pattern.argument_namespace_separator.as_str())
-                                .replace('$', pattern.argument_inner_class_seperator.as_str());
-                            java_args.push_str(&class);
-                        }
-                    }
-                    for _ in 1..levels {
-                        java_args.push_str("%5B%5D"); // []
-                    }
-                    prev_was_array = true; // level 0
+            });
+            if arg.dimensions > 0 {
+                for _ in 1..arg.dimensions {
+                    java_args.push_str("%5B%5D"); // []
                 }
+                prev_was_array = true; // level 0
             }
         }
 
@@ -229,7 +191,7 @@ impl KnownDocsUrl {
         context: &Context,
         java_class: &str,
         java_field: &str,
-        _java_descriptor: field::Descriptor,
+        _java_descriptor: FieldDescriptor,
     ) -> Option<KnownDocsUrl> {
         let pattern = context
             .config

--- a/java-spaghetti-gen/src/emit_rust/known_docs_url.rs
+++ b/java-spaghetti-gen/src/emit_rust/known_docs_url.rs
@@ -131,7 +131,7 @@ impl KnownDocsUrl {
         for arg in method.java.descriptor().parameters.iter() {
             if prev_was_array {
                 prev_was_array = false;
-                java_args.push_str("%5B%5D"); // []
+                java_args.push_str("[]");
             }
 
             if !java_args.is_empty() {
@@ -159,7 +159,7 @@ impl KnownDocsUrl {
             });
             if arg.dimensions > 0 {
                 for _ in 1..arg.dimensions {
-                    java_args.push_str("%5B%5D"); // []
+                    java_args.push_str("[]");
                 }
                 prev_was_array = true; // level 0
             }
@@ -169,7 +169,7 @@ impl KnownDocsUrl {
             if method.java.is_varargs() {
                 java_args.push_str("...");
             } else {
-                java_args.push_str("%5B%5D"); // []
+                java_args.push_str("[]");
             }
         }
 

--- a/java-spaghetti-gen/src/emit_rust/methods.rs
+++ b/java-spaghetti-gen/src/emit_rust/methods.rs
@@ -209,7 +209,8 @@ impl<'a> Method<'a> {
 
         writeln!(
             out,
-            "{indent}    static __METHOD: ::std::sync::OnceLock<usize> = ::std::sync::OnceLock::new();"
+            "{indent}    static __METHOD: ::std::sync::OnceLock<::java_spaghetti::JMethodID> \
+                = ::std::sync::OnceLock::new();"
         )?;
         writeln!(out, "{indent}    unsafe {{")?;
         writeln!(out, "{indent}        let __jni_args = [{params_array}];")?;
@@ -223,9 +224,9 @@ impl<'a> Method<'a> {
         writeln!(
             out,
             "{indent}        \
-            let __jni_method = *__METHOD.get_or_init(|| \
-                __jni_env.require_{}method(__jni_class, {}, {}).addr()\
-            ) as ::java_spaghetti::sys::jmethodID;",
+            let __jni_method = __METHOD.get_or_init(|| \
+                ::java_spaghetti::JMethodID::from_raw(__jni_env.require_{}method(__jni_class, {}, {}))\
+            ).as_raw();",
             if self.java.is_static() { "static_" } else { "" },
             StrEmitter(self.java.name()),
             StrEmitter(MethodSigWriter(self.java.descriptor()))

--- a/java-spaghetti-gen/src/emit_rust/methods.rs
+++ b/java-spaghetti-gen/src/emit_rust/methods.rs
@@ -1,25 +1,28 @@
 use std::io;
 
-use jreflection::method;
+use cafebabe::descriptors::{FieldType, ReturnDescriptor};
 
+use super::fields::FieldTypeEmitter;
 use super::known_docs_url::KnownDocsUrl;
+use super::StrEmitter;
 use crate::emit_rust::Context;
 use crate::identifiers::MethodManglingStyle;
+use crate::parser_util::{Class, JavaMethod, MethodSigWriter};
 
 pub struct Method<'a> {
-    pub class: &'a jreflection::Class,
-    pub java: &'a jreflection::Method,
+    pub class: &'a Class,
+    pub java: JavaMethod<'a>,
     rust_name: Option<String>,
     mangling_style: MethodManglingStyle,
 }
 
 impl<'a> Method<'a> {
-    pub fn new(context: &Context, class: &'a jreflection::Class, java: &'a jreflection::Method) -> Self {
+    pub fn new(context: &Context, class: &'a Class, java: &'a cafebabe::MethodInfo<'a>) -> Self {
         let mut result = Self {
             class,
-            java,
+            java: JavaMethod::from(java),
             rust_name: None,
-            mangling_style: MethodManglingStyle::Java, // Immediately overwritten bellow
+            mangling_style: MethodManglingStyle::Java, // Immediately overwritten below
         };
         result.set_mangling_style(context.config.codegen.method_naming_style); // rust_name + mangling_style
         result
@@ -31,25 +34,21 @@ impl<'a> Method<'a> {
 
     pub fn set_mangling_style(&mut self, style: MethodManglingStyle) {
         self.mangling_style = style;
-        self.rust_name = if let Ok(name) = self
+        self.rust_name = self
             .mangling_style
-            .mangle(self.java.name.as_str(), self.java.descriptor())
-        {
-            Some(name)
-        } else {
-            None // Failed to mangle
-        };
+            .mangle(self.java.name(), self.java.descriptor())
+            .ok()
     }
 
     pub fn emit(&self, context: &Context, mod_: &str, out: &mut impl io::Write) -> io::Result<()> {
         let mut emit_reject_reasons = Vec::new();
 
-        let java_class_method = format!("{}\x1f{}", self.class.path.as_str(), &self.java.name);
+        let java_class_method = format!("{}\x1f{}", self.class.path().as_str(), self.java.name());
         let java_class_method_sig = format!(
             "{}\x1f{}\x1f{}",
-            self.class.path.as_str(),
-            &self.java.name,
-            self.java.descriptor_str()
+            self.class.path().as_str(),
+            self.java.name(),
+            MethodSigWriter(self.java.descriptor())
         );
 
         let ignored = context.config.ignore_class_methods.contains(&java_class_method)
@@ -69,7 +68,7 @@ impl<'a> Method<'a> {
             name.to_owned()
         } else {
             emit_reject_reasons.push("ERROR:  Failed to mangle method name");
-            self.java.name.to_owned()
+            self.java.name().to_owned()
         };
 
         if !self.java.is_public() {
@@ -98,85 +97,22 @@ impl<'a> Method<'a> {
             String::from("self: &::java_spaghetti::Ref<'env, Self>")
         };
 
-        for (arg_idx, arg) in descriptor.arguments().enumerate() {
+        for (arg_idx, arg) in descriptor.parameters.iter().enumerate() {
             let arg_name = format!("arg{}", arg_idx);
 
-            let mut param_is_object = false; // XXX
+            let param_is_object = matches!(arg.field_type, FieldType::Object(_)) || arg.dimensions > 0;
 
-            let arg_type = match arg {
-                method::Type::Single(method::BasicType::Void) => {
-                    emit_reject_reasons.push("ERROR:  Void arguments aren't a thing");
-                    "()".to_owned()
-                }
-                method::Type::Single(method::BasicType::Boolean) => "bool".to_owned(),
-                method::Type::Single(method::BasicType::Byte) => "i8".to_owned(),
-                method::Type::Single(method::BasicType::Char) => "u16".to_owned(),
-                method::Type::Single(method::BasicType::Short) => "i16".to_owned(),
-                method::Type::Single(method::BasicType::Int) => "i32".to_owned(),
-                method::Type::Single(method::BasicType::Long) => "i64".to_owned(),
-                method::Type::Single(method::BasicType::Float) => "f32".to_owned(),
-                method::Type::Single(method::BasicType::Double) => "f64".to_owned(),
-                method::Type::Single(method::BasicType::Class(class)) => {
-                    if !context.all_classes.contains_key(class.as_str()) {
-                        emit_reject_reasons.push("ERROR:  missing class for argument type");
-                    }
-                    param_is_object = true;
-                    match context.java_to_rust_path(class, mod_) {
-                        Ok(path) => format!("impl ::java_spaghetti::AsArg<{}>", path),
-                        Err(_) => {
-                            emit_reject_reasons
-                                .push("ERROR:  Failed to resolve JNI path to Rust path for argument type");
-                            format!("{:?}", class)
-                        }
-                    }
-                }
-                method::Type::Array { levels, inner } => {
-                    let mut buffer = "impl ::java_spaghetti::AsArg<".to_owned();
-                    for _ in 0..(levels - 1) {
-                        buffer.push_str("::java_spaghetti::ObjectArray<");
-                    }
-                    match inner {
-                        method::BasicType::Boolean => buffer.push_str("::java_spaghetti::BooleanArray"),
-                        method::BasicType::Byte => buffer.push_str("::java_spaghetti::ByteArray"),
-                        method::BasicType::Char => buffer.push_str("::java_spaghetti::CharArray"),
-                        method::BasicType::Short => buffer.push_str("::java_spaghetti::ShortArray"),
-                        method::BasicType::Int => buffer.push_str("::java_spaghetti::IntArray"),
-                        method::BasicType::Long => buffer.push_str("::java_spaghetti::LongArray"),
-                        method::BasicType::Float => buffer.push_str("::java_spaghetti::FloatArray"),
-                        method::BasicType::Double => buffer.push_str("::java_spaghetti::DoubleArray"),
-                        method::BasicType::Class(class) => {
-                            if !context.all_classes.contains_key(class.as_str()) {
-                                emit_reject_reasons.push("ERROR:  missing class for argument type");
-                            }
-                            buffer.push_str("::java_spaghetti::ObjectArray<");
-                            match context.java_to_rust_path(class, mod_) {
-                                Ok(path) => buffer.push_str(path.as_str()),
-                                Err(_) => {
-                                    emit_reject_reasons
-                                        .push("ERROR:  Failed to resolve JNI path to Rust path for argument type");
-                                    buffer.push_str("???");
-                                }
-                            }
-                            buffer.push_str(", ");
-                            buffer.push_str(&context.throwable_rust_path(mod_));
-                            buffer.push('>');
-                        }
-                        method::BasicType::Void => {
-                            emit_reject_reasons.push("ERROR:  Arrays of void isn't a thing");
-                            buffer.push_str("[()]");
-                        }
-                    }
-                    for _ in 0..(levels - 1) {
-                        // ObjectArray s
-                        buffer.push_str(", ");
-                        buffer.push_str(&context.throwable_rust_path(mod_));
-                        buffer.push('>');
-                    }
-                    buffer.push_str(">"); // AsArg
+            let rust_type = FieldTypeEmitter(arg)
+                .emit_rust_type(context, mod_, &mut emit_reject_reasons)
+                .map_err(|_| io::Error::other("std::fmt::Error"))?;
 
-                    param_is_object = true;
-                    buffer
-                }
+            let arg_type = if arg.dimensions == 0 && !param_is_object {
+                rust_type.into_owned()
+            } else {
+                let mut rust_type = rust_type.into_owned();
+                rust_type.insert_str(0, "impl ::java_spaghetti::AsArg<");
+                rust_type.push('>');
+                rust_type
             };
 
             if !params_array.is_empty() {
@@ -201,102 +137,34 @@ impl<'a> Method<'a> {
             params_decl.push_str(arg_type.as_str());
         }
 
-        let mut ret_decl = match descriptor.return_type() {
-            // Contents of fn name<'env>() -> Result<...> {
-            method::Type::Single(method::BasicType::Void) => "()".to_owned(),
-            method::Type::Single(method::BasicType::Boolean) => "bool".to_owned(),
-            method::Type::Single(method::BasicType::Byte) => "i8".to_owned(),
-            method::Type::Single(method::BasicType::Char) => "u16".to_owned(),
-            method::Type::Single(method::BasicType::Short) => "i16".to_owned(),
-            method::Type::Single(method::BasicType::Int) => "i32".to_owned(),
-            method::Type::Single(method::BasicType::Long) => "i64".to_owned(),
-            method::Type::Single(method::BasicType::Float) => "f32".to_owned(),
-            method::Type::Single(method::BasicType::Double) => "f64".to_owned(),
-            method::Type::Single(method::BasicType::Class(class)) => {
-                if !context.all_classes.contains_key(class.as_str()) {
-                    emit_reject_reasons.push("ERROR:  missing class for return type");
-                }
-                match context.java_to_rust_path(class, mod_) {
-                    Ok(path) => format!("::std::option::Option<::java_spaghetti::Local<'env, {}>>", path),
-                    Err(_) => {
-                        emit_reject_reasons.push("ERROR:  Failed to resolve JNI path to Rust path for return type");
-                        format!("{:?}", class)
-                    }
-                }
+        let mut ret_decl = if let ReturnDescriptor::Return(desc) = &descriptor.return_type {
+            let rust_type = FieldTypeEmitter(desc)
+                .emit_rust_type(context, mod_, &mut emit_reject_reasons)
+                .map_err(|_| io::Error::other("std::fmt::Error"))?;
+
+            let param_is_object = matches!(desc.field_type, FieldType::Object(_));
+            if desc.dimensions == 0 && !param_is_object {
+                rust_type
+            } else {
+                let mut rust_type = rust_type.into_owned();
+                rust_type.insert_str(0, "::std::option::Option<::java_spaghetti::Local<'env, ");
+                rust_type.push_str(">>");
+                rust_type.into()
             }
-            method::Type::Array {
-                levels: 1,
-                inner: method::BasicType::Void,
-            } => {
-                emit_reject_reasons.push("ERROR:  Returning arrays of void isn't a thing");
-                "???".to_owned()
-            }
-            method::Type::Array { levels, inner } => {
-                let mut buffer = "::std::option::Option<::java_spaghetti::Local<'env, ".to_owned();
-                for _ in 0..(levels - 1) {
-                    buffer.push_str("::java_spaghetti::ObjectArray<");
-                }
-                match inner {
-                    method::BasicType::Boolean => buffer.push_str("::java_spaghetti::BooleanArray"),
-                    method::BasicType::Byte => buffer.push_str("::java_spaghetti::ByteArray"),
-                    method::BasicType::Char => buffer.push_str("::java_spaghetti::CharArray"),
-                    method::BasicType::Short => buffer.push_str("::java_spaghetti::ShortArray"),
-                    method::BasicType::Int => buffer.push_str("::java_spaghetti::IntArray"),
-                    method::BasicType::Long => buffer.push_str("::java_spaghetti::LongArray"),
-                    method::BasicType::Float => buffer.push_str("::java_spaghetti::FloatArray"),
-                    method::BasicType::Double => buffer.push_str("::java_spaghetti::DoubleArray"),
-                    method::BasicType::Class(class) => {
-                        if !context.all_classes.contains_key(class.as_str()) {
-                            emit_reject_reasons.push("ERROR:  missing class for return type");
-                        }
-                        buffer.push_str("::java_spaghetti::ObjectArray<");
-                        match context.java_to_rust_path(class, mod_) {
-                            Ok(path) => buffer.push_str(path.as_str()),
-                            Err(_) => {
-                                emit_reject_reasons
-                                    .push("ERROR:  Failed to resolve JNI path to Rust path for return type");
-                                buffer.push_str("???");
-                            }
-                        }
-                        buffer.push_str(", ");
-                        buffer.push_str(&context.throwable_rust_path(mod_));
-                        buffer.push('>');
-                    }
-                    method::BasicType::Void => {
-                        emit_reject_reasons.push("ERROR:  Arrays of void isn't a thing");
-                        buffer.push_str("[()]");
-                    }
-                }
-                for _ in 0..(levels - 1) {
-                    // ObjectArray s
-                    buffer.push_str(", ");
-                    buffer.push_str(&context.throwable_rust_path(mod_));
-                    buffer.push('>');
-                }
-                buffer.push_str(">>"); // Local, Option
-                buffer
-            }
+        } else {
+            "()".into()
         };
 
-        let mut ret_method_fragment = match descriptor.return_type() {
-            // Contents of call_..._method_a
-            method::Type::Single(method::BasicType::Void) => "void",
-            method::Type::Single(method::BasicType::Boolean) => "boolean",
-            method::Type::Single(method::BasicType::Byte) => "byte",
-            method::Type::Single(method::BasicType::Char) => "char",
-            method::Type::Single(method::BasicType::Short) => "short",
-            method::Type::Single(method::BasicType::Int) => "int",
-            method::Type::Single(method::BasicType::Long) => "long",
-            method::Type::Single(method::BasicType::Float) => "float",
-            method::Type::Single(method::BasicType::Double) => "double",
-            method::Type::Single(method::BasicType::Class(_)) => "object",
-            method::Type::Array { .. } => "object",
+        let mut ret_method_fragment = if let ReturnDescriptor::Return(desc) = &descriptor.return_type {
+            FieldTypeEmitter(desc).emit_fragment_type()
+        } else {
+            "void"
         };
 
         if self.java.is_constructor() {
-            if descriptor.return_type() == method::Type::Single(method::BasicType::Void) {
+            if descriptor.return_type == ReturnDescriptor::Void {
                 ret_method_fragment = "object";
-                ret_decl = "::java_spaghetti::Local<'env, Self>".to_string();
+                ret_decl = "::java_spaghetti::Local<'env, Self>".into();
             } else {
                 emit_reject_reasons.push("ERROR:  Constructor should've returned void");
             }
@@ -312,7 +180,7 @@ impl<'a> Method<'a> {
             "// "
         };
         let access = if self.java.is_public() { "pub " } else { "" };
-        let attributes = (if self.java.deprecated { "#[deprecated] " } else { "" }).to_string();
+        let attributes = if self.java.deprecated() { "#[deprecated] " } else { "" };
 
         writeln!(out)?;
         for reason in &emit_reject_reasons {
@@ -321,7 +189,7 @@ impl<'a> Method<'a> {
         if let Some(url) = KnownDocsUrl::from_method(context, self) {
             writeln!(out, "{}/// {}", indent, url)?;
         } else {
-            writeln!(out, "{}/// {}", indent, self.java.name.as_str())?;
+            writeln!(out, "{}/// {}", indent, self.java.name())?;
         }
         writeln!(
             out,
@@ -336,12 +204,12 @@ impl<'a> Method<'a> {
         )?;
         writeln!(
             out,
-            "{}    // class.path == {:?}, java.flags == {:?}, .name == {:?}, .descriptor == {:?}",
+            "{}    // class.path == {:?}, java.flags == {:?}, .name == {:?}, .descriptor == \"{}\"",
             indent,
-            &self.class.path.as_str(),
-            self.java.flags,
-            &self.java.name,
-            &self.java.descriptor_str()
+            self.class.path().as_str(),
+            self.java.access_flags,
+            self.java.name(),
+            MethodSigWriter(self.java.descriptor())
         )?;
         writeln!(out, "{}    unsafe {{", indent)?;
         writeln!(out, "{}        let __jni_args = [{}];", indent, params_array)?;
@@ -354,9 +222,9 @@ impl<'a> Method<'a> {
             "{}        let (__jni_class, __jni_method) = __jni_env.require_class_{}method({}, {}, {});",
             indent,
             if self.java.is_static() { "static_" } else { "" },
-            emit_cstr(self.class.path.as_str()),
-            emit_cstr(self.java.name.as_str()),
-            emit_cstr(self.java.descriptor_str())
+            StrEmitter(self.class.path().as_str()),
+            StrEmitter(self.java.name()),
+            StrEmitter(MethodSigWriter(self.java.descriptor()))
         )?;
 
         if self.java.is_constructor() {
@@ -382,10 +250,4 @@ impl<'a> Method<'a> {
         writeln!(out, "{}}}", indent)?;
         Ok(())
     }
-}
-
-fn emit_cstr(s: &str) -> String {
-    let mut s = format!("{:?}", s); // XXX
-    s.insert_str(s.len() - 1, "\\0");
-    s
 }

--- a/java-spaghetti-gen/src/emit_rust/mod.rs
+++ b/java-spaghetti-gen/src/emit_rust/mod.rs
@@ -9,3 +9,20 @@ mod preamble;
 mod structs;
 
 pub use context::Context;
+
+/// Writes the string (with "\0" added at the right side) surrounded by double quotes.
+///
+/// XXX: This implementation (as well as `Env` methods in `java-spaghetti` crate)
+/// should probably use byte slices so that full Unicode support can be made possible:
+/// JNI `GetFieldID` and `GetMethodID` expects *modified* UTF-8 string name and signature.
+/// Note: `cafebabe` converts modified UTF-8 string to real UTF-8 string at first hand.
+struct StrEmitter<T: std::fmt::Display>(pub T);
+
+impl<T: std::fmt::Display> std::fmt::Display for StrEmitter<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::fmt::Write;
+        f.write_char('\"')?;
+        self.0.fmt(f)?;
+        f.write_str("\\0\"")
+    }
+}

--- a/java-spaghetti-gen/src/emit_rust/structs.rs
+++ b/java-spaghetti-gen/src/emit_rust/structs.rs
@@ -3,13 +3,12 @@ use std::error::Error;
 use std::fmt::Write;
 use std::io;
 
-use jreflection::class;
-
 use super::fields::Field;
 use super::known_docs_url::KnownDocsUrl;
 use super::methods::Method;
 use crate::emit_rust::Context;
 use crate::identifiers::{FieldMangling, RustIdentifier};
+use crate::parser_util::{Class, Id, IdPart};
 
 #[derive(Debug, Default)]
 pub(crate) struct StructPaths {
@@ -18,7 +17,7 @@ pub(crate) struct StructPaths {
 }
 
 impl StructPaths {
-    pub(crate) fn new(context: &Context, class: class::Id) -> Result<Self, Box<dyn Error>> {
+    pub(crate) fn new(context: &Context, class: Id) -> Result<Self, Box<dyn Error>> {
         Ok(Self {
             mod_: Struct::mod_for(context, class)?,
             struct_name: Struct::name_for(context, class)?,
@@ -26,10 +25,10 @@ impl StructPaths {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct Struct {
     pub rust: StructPaths,
-    pub java: jreflection::Class,
+    pub java: Class,
 }
 
 fn rust_id(id: &str) -> Result<String, Box<dyn Error>> {
@@ -45,24 +44,24 @@ fn rust_id(id: &str) -> Result<String, Box<dyn Error>> {
 }
 
 impl Struct {
-    pub(crate) fn mod_for(_context: &Context, class: class::Id) -> Result<String, Box<dyn Error>> {
+    pub(crate) fn mod_for(_context: &Context, class: Id) -> Result<String, Box<dyn Error>> {
         let mut buf = String::new();
-        for component in class.iter() {
+        for component in class {
             match component {
-                class::IdPart::Namespace(id) => {
+                IdPart::Namespace(id) => {
                     if !buf.is_empty() {
                         buf.push_str("::");
                     }
                     buf.push_str(&rust_id(id)?);
                 }
-                class::IdPart::ContainingClass(_) => {}
-                class::IdPart::LeafClass(_) => {}
+                IdPart::ContainingClass(_) => {}
+                IdPart::LeafClass(_) => {}
             }
         }
         Ok(buf)
     }
 
-    pub(crate) fn name_for(context: &Context, class: class::Id) -> Result<String, Box<dyn Error>> {
+    pub(crate) fn name_for(context: &Context, class: Id) -> Result<String, Box<dyn Error>> {
         let rename_to = context
             .config
             .rename_classes
@@ -72,9 +71,9 @@ impl Struct {
         let mut buf = String::new();
         for component in class.iter() {
             match component {
-                class::IdPart::Namespace(_) => {}
-                class::IdPart::ContainingClass(id) => write!(&mut buf, "{}_", rust_id(id)?)?,
-                class::IdPart::LeafClass(id) => write!(
+                IdPart::Namespace(_) => {}
+                IdPart::ContainingClass(id) => write!(&mut buf, "{}_", rust_id(id)?)?,
+                IdPart::LeafClass(id) => write!(
                     &mut buf,
                     "{}",
                     rename_to.map(ToString::to_string).or_else(|_| rust_id(id))?
@@ -84,8 +83,8 @@ impl Struct {
         Ok(buf)
     }
 
-    pub(crate) fn new(context: &mut Context, java: jreflection::Class) -> Result<Self, Box<dyn Error>> {
-        let rust = StructPaths::new(context, java.path.as_id())?;
+    pub(crate) fn new(context: &mut Context, java: Class) -> Result<Self, Box<dyn Error>> {
+        let rust = StructPaths::new(context, java.path())?;
 
         Ok(Self { rust, java })
     }
@@ -108,12 +107,12 @@ impl Struct {
         };
 
         let visibility = if self.java.is_public() { "pub" } else { "" };
-        let attributes = (if self.java.deprecated { "#[deprecated] " } else { "" }).to_string();
+        let attributes = (if self.java.deprecated() { "#[deprecated] " } else { "" }).to_string();
 
-        if let Some(url) = KnownDocsUrl::from_class(context, self.java.path.as_id()) {
+        if let Some(url) = KnownDocsUrl::from_class(context, self.java.path()) {
             writeln!(out, "/// {} {} {}", visibility, keyword, url)?;
         } else {
-            writeln!(out, "/// {} {} {}", visibility, keyword, self.java.path.as_str())?;
+            writeln!(out, "/// {} {} {}", visibility, keyword, self.java.path().as_str())?;
         }
 
         let rust_name = &self.rust.struct_name;
@@ -128,25 +127,25 @@ impl Struct {
                     callback({:?})
                 }}
             }}",
-            self.java.path.as_str().to_string() + "\0",
+            self.java.path().as_str().to_string() + "\0",
         )?;
 
         // recursively visit all superclasses and superinterfaces.
         let mut queue = Vec::new();
         let mut visited = HashSet::new();
-        queue.push(self.java.path.clone());
-        visited.insert(self.java.path.clone());
+        queue.push(self.java.path());
+        visited.insert(self.java.path());
         while let Some(path) = queue.pop() {
             let class = context.all_classes.get(path.as_str()).unwrap();
-            for path2 in self.java.interfaces.iter().chain(class.java.super_path.as_ref()) {
-                if context.all_classes.contains_key(path2.as_str()) && !visited.contains(path2) {
-                    let rust_path = context.java_to_rust_path(path2.as_id(), &self.rust.mod_).unwrap();
+            for path2 in self.java.interfaces().map(|i| Id(i)).chain(class.java.super_path()) {
+                if context.all_classes.contains_key(path2.as_str()) && !visited.contains(&path2) {
+                    let rust_path = context.java_to_rust_path(path2, &self.rust.mod_).unwrap();
                     writeln!(
                         out,
                         "unsafe impl ::java_spaghetti::AssignableTo<{rust_path}> for {rust_name} {{}}"
                     )?;
-                    queue.push(path2.clone());
-                    visited.insert(path2.clone());
+                    queue.push(path2);
+                    visited.insert(path2);
                 }
             }
         }
@@ -157,16 +156,10 @@ impl Struct {
 
         let mut methods: Vec<Method> = self
             .java
-            .methods
-            .iter()
+            .methods()
             .map(|m| Method::new(context, &self.java, m))
             .collect();
-        let mut fields: Vec<Field> = self
-            .java
-            .fields
-            .iter()
-            .map(|f| Field::new(context, &self.java, f))
-            .collect();
+        let mut fields: Vec<Field> = self.java.fields().map(|f| Field::new(context, &self.java, f)).collect();
 
         for method in &methods {
             if !method.java.is_public() {

--- a/java-spaghetti-gen/src/main.rs
+++ b/java-spaghetti-gen/src/main.rs
@@ -1,9 +1,10 @@
-// must go first because macros.
+// this must go first because of macros.
 mod util;
 
 mod config;
 mod emit_rust;
 mod identifiers;
+mod parser_util;
 mod run;
 
 fn main() {
@@ -18,7 +19,7 @@ mod entry {
     use crate::config;
     use crate::run::run;
 
-    /// Autogenerate jni-android-sys, glue code for access Android JVM APIs from Rust
+    /// Autogenerate glue code for access Android JVM APIs from Rust
     #[derive(Parser, Debug)]
     #[command(version, about)]
     struct Cli {
@@ -49,7 +50,11 @@ mod entry {
         match cli.cmd {
             Cmd::Generate(cmd) => {
                 let config_file = config::toml::File::from_directory(&cmd.directory).unwrap();
-                run(config_file).unwrap();
+                let mut config: config::runtime::Config = config_file.into();
+                if cmd.verbose {
+                    config.logging_verbose = true;
+                }
+                run(config).unwrap();
             }
         }
     }

--- a/java-spaghetti-gen/src/parser_util/class.rs
+++ b/java-spaghetti-gen/src/parser_util/class.rs
@@ -1,0 +1,105 @@
+use std::borrow::Cow;
+
+use cafebabe::attributes::AttributeData;
+pub use cafebabe::ClassAccessFlags;
+pub use unsafe_class::Class;
+
+use super::Id;
+mod unsafe_class {
+    use std::marker::PhantomPinned;
+    use std::pin::Pin;
+
+    #[derive(Debug)]
+    pub struct Class {
+        #[allow(unused)]
+        raw_bytes: Pin<Box<(Vec<u8>, PhantomPinned)>>,
+        inner: cafebabe::ClassFile<'static>,
+    }
+
+    impl Class {
+        pub fn read(raw_bytes: Vec<u8>) -> Result<Self, cafebabe::ParseError> {
+            let pinned = Box::pin((raw_bytes, PhantomPinned));
+            // SAFETY: `get<'a>(&'a self)` restricts the lifetime parameter of
+            // the returned referenced `ClassFile`.
+            let fake_static = unsafe { std::slice::from_raw_parts(pinned.0.as_ptr(), pinned.0.len()) };
+            let inner = cafebabe::parse_class(fake_static)?;
+            Ok(Self {
+                raw_bytes: pinned,
+                inner,
+            })
+        }
+
+        // It is probably not possible to implement `Deref` safely.
+        pub fn get<'a>(&'a self) -> &'a cafebabe::ClassFile<'a> {
+            // SAFETY: casts `self.inner` into `cafebabe::ClassFile<'a>` forcefully.
+            // `cafebabe::parse_class` takes immutable &'a [u8], why is the returned
+            // `ClassFile<'a>` invariant over `'a`?
+            unsafe { &*(&raw const (self.inner)).cast() }
+        }
+    }
+}
+
+impl Class {
+    fn flags(&self) -> ClassAccessFlags {
+        self.get().access_flags
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::PUBLIC)
+    }
+    pub fn is_final(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::FINAL)
+    }
+    pub fn is_static(&self) -> bool {
+        (self.flags().bits() & 0x0008) != 0
+    }
+    #[allow(unused)]
+    pub fn is_super(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::SUPER)
+    }
+    pub fn is_interface(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::INTERFACE)
+    }
+    #[allow(unused)]
+    pub fn is_abstract(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::ABSTRACT)
+    }
+    #[allow(unused)]
+    pub fn is_synthetic(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::SYNTHETIC)
+    }
+    #[allow(unused)]
+    pub fn is_annotation(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::ANNOTATION)
+    }
+    pub fn is_enum(&self) -> bool {
+        self.flags().contains(ClassAccessFlags::ENUM)
+    }
+
+    pub fn path(&self) -> Id<'_> {
+        Id(self.get().this_class.as_ref())
+    }
+
+    pub fn super_path(&self) -> Option<Id<'_>> {
+        self.get().super_class.as_ref().map(|class| Id(class))
+    }
+
+    pub fn interfaces(&self) -> std::slice::Iter<'_, Cow<'_, str>> {
+        self.get().interfaces.iter()
+    }
+
+    pub fn fields(&self) -> std::slice::Iter<'_, cafebabe::FieldInfo<'_>> {
+        self.get().fields.iter()
+    }
+
+    pub fn methods(&self) -> std::slice::Iter<'_, cafebabe::MethodInfo<'_>> {
+        self.get().methods.iter()
+    }
+
+    pub fn deprecated(&self) -> bool {
+        self.get()
+            .attributes
+            .iter()
+            .any(|attr| matches!(attr.data, AttributeData::Deprecated))
+    }
+}

--- a/java-spaghetti-gen/src/parser_util/field.rs
+++ b/java-spaghetti-gen/src/parser_util/field.rs
@@ -1,0 +1,138 @@
+use std::fmt::Write;
+
+use cafebabe::attributes::AttributeData;
+use cafebabe::constant_pool::LiteralConstant;
+use cafebabe::descriptors::{FieldDescriptor, FieldType};
+use cafebabe::FieldAccessFlags;
+
+use super::ClassName;
+
+#[derive(Clone, Copy, Debug)]
+pub struct JavaField<'a> {
+    java: &'a cafebabe::FieldInfo<'a>,
+}
+
+impl<'a> From<&'a cafebabe::FieldInfo<'a>> for JavaField<'a> {
+    fn from(value: &'a cafebabe::FieldInfo<'a>) -> Self {
+        Self { java: value }
+    }
+}
+
+impl<'a> std::ops::Deref for JavaField<'a> {
+    type Target = cafebabe::FieldInfo<'a>;
+    fn deref(&self) -> &Self::Target {
+        self.java
+    }
+}
+
+impl<'a> JavaField<'a> {
+    pub fn name<'s>(&'s self) -> &'a str {
+        self.java.name.as_ref()
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::PUBLIC)
+    }
+    pub fn is_private(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::PRIVATE)
+    }
+    pub fn is_protected(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::PROTECTED)
+    }
+    pub fn is_static(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::STATIC)
+    }
+    pub fn is_final(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::FINAL)
+    }
+    pub fn is_volatile(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::VOLATILE)
+    }
+    #[allow(unused)]
+    pub fn is_transient(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::TRANSIENT)
+    }
+    #[allow(unused)]
+    pub fn is_synthetic(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::SYNTHETIC)
+    }
+    #[allow(unused)]
+    pub fn is_enum(&self) -> bool {
+        self.access_flags.contains(FieldAccessFlags::ENUM)
+    }
+
+    pub fn access(&self) -> Option<&'static str> {
+        if self.is_private() {
+            Some("private")
+        } else if self.is_protected() {
+            Some("protected")
+        } else if self.is_public() {
+            Some("public")
+        } else {
+            None
+        }
+    }
+
+    pub fn is_constant(&self) -> bool {
+        self.is_static()
+            && self.is_final()
+            && self
+                .attributes
+                .iter()
+                .any(|attr| matches!(&attr.data, AttributeData::ConstantValue(_)))
+    }
+
+    pub fn constant<'s>(&'s self) -> Option<LiteralConstant<'a>> {
+        if !self.is_static() || !self.is_final() {
+            return None;
+        }
+        self.attributes.iter().find_map(|attr| {
+            if let AttributeData::ConstantValue(c) = &attr.data {
+                Some(c.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn deprecated(&self) -> bool {
+        self.attributes
+            .iter()
+            .any(|attr| matches!(attr.data, AttributeData::Deprecated))
+    }
+
+    pub fn descriptor<'s>(&'s self) -> &'a FieldDescriptor<'a> {
+        &self.java.descriptor
+    }
+}
+
+// XXX: cannot get the original string from `cafebabe::descriptors::FieldDescriptor`.
+// <https://github.com/staktrace/cafebabe/issues/52>
+pub struct FieldSigWriter<'a>(pub &'a FieldDescriptor<'a>);
+
+impl std::fmt::Display for FieldSigWriter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let descriptor = self.0;
+        for _ in 0..descriptor.dimensions {
+            f.write_char('[')?;
+        }
+        if let FieldType::Object(class_name) = &descriptor.field_type {
+            f.write_char('L')?;
+            ClassName::from(class_name).fmt(f)?;
+            f.write_char(';')
+        } else {
+            let ch = match descriptor.field_type {
+                FieldType::Boolean => 'Z',
+                FieldType::Byte => 'B',
+                FieldType::Char => 'C',
+                FieldType::Short => 'S',
+                FieldType::Integer => 'I',
+                FieldType::Long => 'J',
+                FieldType::Float => 'F',
+                FieldType::Double => 'D',
+                _ => unreachable!(),
+            };
+            f.write_char(ch)
+        }
+    }
+}

--- a/java-spaghetti-gen/src/parser_util/id.rs
+++ b/java-spaghetti-gen/src/parser_util/id.rs
@@ -1,0 +1,233 @@
+// Migrated from <https://docs.rs/jreflection/0.0.11/src/jreflection/class.rs.html>.
+
+use std::fmt::Write;
+
+/// Owned Java class binary name (internal form).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct IdBuf(String);
+
+impl IdBuf {
+    pub fn new(s: String) -> Self {
+        Self(s)
+    }
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+    pub fn as_id(&self) -> Id {
+        Id(self.0.as_str())
+    }
+    #[allow(dead_code)]
+    pub fn iter(&self) -> IdIter {
+        IdIter::new(self.0.as_str())
+    }
+}
+
+// XXX: This should really be `#[repr(transparent)] pub struct Id(str);`...
+// Also, patterns apparently can't handle Id::new(...) even when it's a const fn.
+
+/// Borrowed Java class binary name (internal form).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Id<'a>(pub &'a str);
+
+impl<'a> Id<'a> {
+    pub fn as_str(&self) -> &'a str {
+        self.0
+    }
+    pub fn iter(&self) -> IdIter<'a> {
+        IdIter::new(self.0)
+    }
+}
+
+impl<'a> IntoIterator for Id<'a> {
+    type Item = IdPart<'a>;
+    type IntoIter = IdIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum IdPart<'a> {
+    Namespace(&'a str),
+    ContainingClass(&'a str),
+    LeafClass(&'a str),
+}
+
+/// Iterates through names of namespaces, superclasses and the "leaf" class
+/// in the Java class binary name.
+pub struct IdIter<'a> {
+    rest: &'a str,
+}
+
+impl<'a> IdIter<'a> {
+    pub fn new(path: &'a str) -> Self {
+        IdIter { rest: path }
+    }
+}
+
+impl<'a> Iterator for IdIter<'a> {
+    type Item = IdPart<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(slash) = self.rest.find('/') {
+            let (namespace, rest) = self.rest.split_at(slash);
+            self.rest = &rest[1..];
+            return Some(IdPart::Namespace(namespace));
+        }
+
+        if let Some(dollar) = self.rest.find('$') {
+            let (class, rest) = self.rest.split_at(dollar);
+            self.rest = &rest[1..];
+            return Some(IdPart::ContainingClass(class));
+        }
+
+        if !self.rest.is_empty() {
+            let class = self.rest;
+            self.rest = "";
+            return Some(IdPart::LeafClass(class));
+        }
+
+        None
+    }
+}
+
+#[test]
+fn id_iter_test() {
+    assert_eq!(Id("").iter().collect::<Vec<_>>(), &[]);
+
+    assert_eq!(Id("Bar").iter().collect::<Vec<_>>(), &[IdPart::LeafClass("Bar"),]);
+
+    assert_eq!(
+        Id("java/foo/Bar").iter().collect::<Vec<_>>(),
+        &[
+            IdPart::Namespace("java"),
+            IdPart::Namespace("foo"),
+            IdPart::LeafClass("Bar"),
+        ]
+    );
+
+    assert_eq!(
+        Id("java/foo/Bar$Inner").iter().collect::<Vec<_>>(),
+        &[
+            IdPart::Namespace("java"),
+            IdPart::Namespace("foo"),
+            IdPart::ContainingClass("Bar"),
+            IdPart::LeafClass("Inner"),
+        ]
+    );
+
+    assert_eq!(
+        Id("java/foo/Bar$Inner$MoreInner").iter().collect::<Vec<_>>(),
+        &[
+            IdPart::Namespace("java"),
+            IdPart::Namespace("foo"),
+            IdPart::ContainingClass("Bar"),
+            IdPart::ContainingClass("Inner"),
+            IdPart::LeafClass("MoreInner"),
+        ]
+    );
+}
+
+/// Newtype for `cafebabe::descriptors::ClassName`.
+///
+/// XXX: cannot get the original string from `cafebabe::descriptors::ClassName`; the binary
+/// name is split into `UnqualifiedSegment`s, not caring about Java-specific nested classes.
+/// See <https://github.com/staktrace/cafebabe/issues/52>.
+#[derive(Clone, Copy, Debug)]
+pub struct ClassName<'a> {
+    inner: &'a cafebabe::descriptors::ClassName<'a>,
+}
+
+impl<'a> From<&'a cafebabe::descriptors::ClassName<'a>> for ClassName<'a> {
+    fn from(value: &'a cafebabe::descriptors::ClassName<'a>) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl<'a> std::ops::Deref for ClassName<'a> {
+    type Target = cafebabe::descriptors::ClassName<'a>;
+    fn deref(&self) -> &Self::Target {
+        self.inner
+    }
+}
+
+impl std::fmt::Display for ClassName<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut segs = self.segments.iter();
+        f.write_str(segs.next().unwrap().name.as_ref())?;
+        for seg in segs {
+            f.write_char('/')?;
+            f.write_str(seg.name.as_ref())?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> From<&ClassName<'a>> for IdBuf {
+    fn from(value: &ClassName<'a>) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
+impl<'a> From<&cafebabe::descriptors::ClassName<'a>> for IdBuf {
+    fn from(value: &cafebabe::descriptors::ClassName<'a>) -> Self {
+        Self::new(ClassName::from(value).to_string())
+    }
+}
+
+impl<'a> ClassName<'a> {
+    pub fn iter<'s>(&'s self) -> ClassNameIter<'a> {
+        let segments = &self.inner.segments;
+        if segments.len() > 1 {
+            ClassNameIter::RestPath(segments)
+        } else {
+            let classes = segments.last().map(|s| s.name.as_ref()).unwrap_or("");
+            ClassNameIter::RestClasses(IdIter::new(classes))
+        }
+    }
+}
+
+impl<'a> IntoIterator for ClassName<'a> {
+    type Item = IdPart<'a>;
+    type IntoIter = ClassNameIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub enum ClassNameIter<'a> {
+    RestPath(&'a [cafebabe::descriptors::UnqualifiedSegment<'a>]),
+    RestClasses(IdIter<'a>),
+}
+
+impl<'a> Iterator for ClassNameIter<'a> {
+    type Item = IdPart<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::RestPath(segments) => {
+                // `segments.len() > 1` must be true at here
+                let namespace = IdPart::Namespace(&segments[0].name);
+                *self = if segments.len() - 1 > 1 {
+                    Self::RestPath(&segments[1..])
+                } else {
+                    Self::RestClasses(IdIter::new(&segments.last().unwrap().name))
+                };
+                Some(namespace)
+            }
+            Self::RestClasses(ref mut id_iter) => id_iter.next(),
+        }
+    }
+}
+
+#[allow(unused)]
+pub trait IterableId<'a>: IntoIterator<Item = IdPart<'a>> + Copy {
+    fn is_string_class(self) -> bool {
+        let mut iter = self.into_iter();
+        iter.next() == Some(IdPart::Namespace("java"))
+            && iter.next() == Some(IdPart::Namespace("lang"))
+            && iter.next() == Some(IdPart::LeafClass("String"))
+            && iter.next().is_none()
+    }
+}
+
+impl<'a> IterableId<'a> for Id<'a> {}
+impl<'a> IterableId<'a> for ClassName<'a> {}

--- a/java-spaghetti-gen/src/parser_util/method.rs
+++ b/java-spaghetti-gen/src/parser_util/method.rs
@@ -1,0 +1,125 @@
+use std::fmt::Write;
+
+use cafebabe::attributes::AttributeData;
+use cafebabe::descriptors::{MethodDescriptor, ReturnDescriptor};
+use cafebabe::MethodAccessFlags;
+
+use super::FieldSigWriter;
+
+pub struct JavaMethod<'a> {
+    java: &'a cafebabe::MethodInfo<'a>,
+}
+
+impl<'a> From<&'a cafebabe::MethodInfo<'a>> for JavaMethod<'a> {
+    fn from(value: &'a cafebabe::MethodInfo<'a>) -> Self {
+        Self { java: value }
+    }
+}
+
+impl<'a> std::ops::Deref for JavaMethod<'a> {
+    type Target = cafebabe::MethodInfo<'a>;
+    fn deref(&self) -> &Self::Target {
+        self.java
+    }
+}
+
+impl<'a> JavaMethod<'a> {
+    pub fn name<'s>(&'s self) -> &'a str {
+        self.java.name.as_ref()
+    }
+
+    pub fn is_public(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::PUBLIC)
+    }
+    #[allow(unused)]
+    pub fn is_private(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::PRIVATE)
+    }
+    #[allow(unused)]
+    pub fn is_protected(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::PROTECTED)
+    }
+    pub fn is_static(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::STATIC)
+    }
+    #[allow(unused)]
+    pub fn is_final(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::FINAL)
+    }
+    #[allow(unused)]
+    pub fn is_synchronized(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::SYNCHRONIZED)
+    }
+    pub fn is_bridge(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::BRIDGE)
+    }
+    pub fn is_varargs(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::VARARGS)
+    }
+    #[allow(unused)]
+    pub fn is_native(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::NATIVE)
+    }
+    #[allow(unused)]
+    pub fn is_abstract(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::ABSTRACT)
+    }
+    #[allow(unused)]
+    pub fn is_strict(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::STRICT)
+    }
+    #[allow(unused)]
+    pub fn is_synthetic(&self) -> bool {
+        self.access_flags.contains(MethodAccessFlags::SYNTHETIC)
+    }
+
+    pub fn is_constructor(&self) -> bool {
+        self.name() == "<init>"
+    }
+    pub fn is_static_init(&self) -> bool {
+        self.name() == "<clinit>"
+    }
+
+    #[allow(unused)]
+    pub fn access(&self) -> Option<&'static str> {
+        if self.is_private() {
+            Some("private")
+        } else if self.is_protected() {
+            Some("protected")
+        } else if self.is_public() {
+            Some("public")
+        } else {
+            None
+        }
+    }
+
+    pub fn deprecated(&self) -> bool {
+        self.attributes
+            .iter()
+            .any(|attr| matches!(attr.data, AttributeData::Deprecated))
+    }
+
+    pub fn descriptor<'s>(&'s self) -> &'a MethodDescriptor<'a> {
+        &self.java.descriptor
+    }
+}
+
+// XXX: cannot get the original string from `cafebabe::descriptors::MethodDescriptor`.
+// <https://github.com/staktrace/cafebabe/issues/52>
+pub struct MethodSigWriter<'a>(pub &'a MethodDescriptor<'a>);
+
+impl std::fmt::Display for MethodSigWriter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let descriptor = self.0;
+        f.write_char('(')?;
+        for arg in descriptor.parameters.iter() {
+            FieldSigWriter(arg).fmt(f)?;
+        }
+        f.write_char(')')?;
+        if let ReturnDescriptor::Return(desc) = &descriptor.return_type {
+            FieldSigWriter(desc).fmt(f)
+        } else {
+            f.write_char('V')
+        }
+    }
+}

--- a/java-spaghetti-gen/src/parser_util/mod.rs
+++ b/java-spaghetti-gen/src/parser_util/mod.rs
@@ -1,0 +1,9 @@
+mod class;
+mod field;
+mod id;
+mod method;
+
+pub use class::Class;
+pub use field::{FieldSigWriter, JavaField};
+pub use id::*;
+pub use method::{JavaMethod, MethodSigWriter};

--- a/java-spaghetti-gen/src/util/difference.rs
+++ b/java-spaghetti-gen/src/util/difference.rs
@@ -1,8 +1,12 @@
 use std::io::{self, *};
 
 pub struct Difference {
+    // XXX: should they exist here?
+    #[allow(unused)]
     pub line_no: u32,
+    #[allow(unused)]
     pub original: String,
+    #[allow(unused)]
     pub rewrite: String,
 }
 

--- a/java-spaghetti/src/id_cache.rs
+++ b/java-spaghetti/src/id_cache.rs
@@ -1,0 +1,62 @@
+//! New types for `jfieldID` and `jmethodID` that implement `Send` and `Sync`.
+//!
+//! Inspired by: <https://docs.rs/jni/0.21.1/jni/objects/struct.JMethodID.html>.
+//!
+//! According to the JNI spec field IDs may be invalidated when the corresponding class is unloaded:
+//! <https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#accessing_fields_and_methods>
+//!
+//! You should generally not be interacting with these types directly, but it must be public for codegen.
+
+use crate::sys::{jfieldID, jmethodID};
+
+#[doc(hidden)]
+#[repr(transparent)]
+pub struct JFieldID {
+    internal: jfieldID,
+}
+
+// Field IDs are valid across threads (not tied to a JNIEnv)
+unsafe impl Send for JFieldID {}
+unsafe impl Sync for JFieldID {}
+
+impl JFieldID {
+    /// Creates a [`JFieldID`] that wraps the given `raw` [`jfieldID`].
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid, non-`null` ID.
+    pub unsafe fn from_raw(raw: jfieldID) -> Self {
+        debug_assert!(!raw.is_null(), "from_raw fieldID argument");
+        Self { internal: raw }
+    }
+
+    pub fn as_raw(&self) -> jfieldID {
+        self.internal
+    }
+}
+
+#[doc(hidden)]
+#[repr(transparent)]
+pub struct JMethodID {
+    internal: jmethodID,
+}
+
+// Method IDs are valid across threads (not tied to a JNIEnv)
+unsafe impl Send for JMethodID {}
+unsafe impl Sync for JMethodID {}
+
+impl JMethodID {
+    /// Creates a [`JMethodID`] that wraps the given `raw` [`jmethodID`].
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid, non-`null` ID.
+    pub unsafe fn from_raw(raw: jmethodID) -> Self {
+        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+        Self { internal: raw }
+    }
+
+    pub fn as_raw(&self) -> jmethodID {
+        self.internal
+    }
+}

--- a/java-spaghetti/src/lib.rs
+++ b/java-spaghetti/src/lib.rs
@@ -29,6 +29,7 @@ mod refs {
 mod array;
 mod as_jvalue;
 mod env;
+mod id_cache;
 mod jni_type;
 mod string_chars;
 mod vm;
@@ -36,6 +37,7 @@ mod vm;
 pub use array::*;
 pub use as_jvalue::*;
 pub use env::*;
+pub use id_cache::*;
 pub use jni_type::JniType;
 pub use refs::*;
 pub use string_chars::*;

--- a/java-spaghetti/src/vm.rs
+++ b/java-spaghetti/src/vm.rs
@@ -29,6 +29,12 @@ impl VM {
         self.0
     }
 
+    /// Constructs `VM` with a valid `jni_sys::JavaVM` raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// - Make sure the corresponding JVM will keep alive within the lifetime of current native library or application.
+    /// - Do not use any class redefinition feature, which may break the validity of method/field IDs to be cached.
     pub unsafe fn from_raw(vm: *mut JavaVM) -> Self {
         Self(vm)
     }


### PR DESCRIPTION
### Commit 1: Port java-spaghetti-gen to cafebabe

Introduced `cafebabe` as an alternative to the unmaintained `jreflection` crate. However, there are some workarounds for <https://github.com/staktrace/cafebabe/issues/52>.

Difference of execution speed (release build) cannot be realized.

The generated `bindings.rs` for the whole `android.jar` keeps the same, except these differences:
- `java.flags` comment: SYNCRONIZED -> SYNCHRONIZED
- documentation URL comment: `bool%5B%5D` -> `boolean%5B%5D` (`bool` was a bug)
- const values for NaN and INFINITY: `__jni_bindgen` namespace is removed

### Commit 2: Fix java-spaghetti-gen reference URL generation

Documentation URL comment generation: changed `%5B%5D` to `[]`, because the android documentation website uses `[]` directly in URLs for now, and links like <https://developer.android.com/reference/android/icu/util/Currency.html#getName(java.util.Locale,%20int,%20boolean%5B%5D)> cannot jump to the correct item.

### Commit 3: Cache method/field ID; fix jclass memory leaks

This is a significant performance improvement. Caching method/field IDs may encounter validity issues: <https://mostlynerdless.de/blog/2023/07/17/jmethodids-in-profiling-a-tale-of-nightmares/>; I try to avoid the problem by holding a global reference of the class object for each class being used.

Test case:

```toml
include = [
    "java/lang/Object",
    "java/lang/Throwable",
    "java/lang/StackTraceElement",
    "java/lang/String",
    "java/lang/Integer"
]

[[documentation.pattern]]
class_url_pattern           = "https://developer.android.com/reference/{CLASS}.html"
method_url_pattern          = "https://developer.android.com/reference/{CLASS}.html#{METHOD}({ARGUMENTS})"
constructor_url_pattern     = "https://developer.android.com/reference/{CLASS}.html#{CLASS.INNER}({ARGUMENTS})"
field_url_pattern           = "https://developer.android.com/reference/{CLASS}.html#{FIELD}"
argument_seperator          = ",%20"

[logging]
verbose = true

[input]
files = [
    # To be modified
    "E:\\android\\platforms\\android-30\\android.jar",
]

[output]
path = "bindings.rs"

[codegen]
method_naming_style             = "java"
method_naming_style_collision   = "java_short_signature"
keep_rejected_emits             = false

[codegen.field_naming_style]
const_finals    = true
rustify_names   = false
getter_pattern  = "{NAME}"
setter_pattern  = "set_{NAME}"
```

```rust
#![feature(arbitrary_self_types)]
mod bindings;
use bindings::java;

pub fn get_vm() -> java_spaghetti::VM {
    let vm = ndk_context::android_context().vm();
    if vm.is_null() {
        panic!("ndk-context is unconfigured: null JVM pointer, check the glue crate.");
    }
    unsafe { java_spaghetti::VM::from_raw(vm.cast()) }
}

#[no_mangle]
fn android_main(_: android_activity::AndroidApp) ->  Result<(), Box<dyn std::error::Error>> {
    android_logger::init_once(
        android_logger::Config::default()
            .with_max_level(log::LevelFilter::Info)
            .with_tag("java_spaghetti_test".as_bytes()),
    );

    let vm = get_vm();
    let t_exec = vm.with_env(|env| {
        measure_exec_seconds(|| {
            let integer = java::lang::Integer::valueOf_int(env, 31)?.unwrap();
            for _ in 0..100*1000*1000 {
                let n = integer.intValue().unwrap();
                assert_eq!(n, 31);
            }
            Ok::<(), java_spaghetti::Local<'_, java::lang::Throwable>>(())
        })
    });

    log::info!("Time elapsed: {t_exec} s");
    Ok(())
}

fn measure_exec_seconds<T, F: FnOnce() -> T>(fn_exec: F) -> f64 {
    use std::time::Instant;
    let t_start = Instant::now();
    let _ = fn_exec();
    Instant::now().duration_since(t_start).as_secs_f64()
}
```

```toml
# For cargo-apk

[package]
name = "java-spaghetti-test"
version = "0.1.0"
edition = "2021"
publish = false

[dependencies]
log = "0.4"
java-spaghetti = { path = "../java-spaghetti" }
android-activity = { version = "0.6", features = ["native-activity"] }
android_logger = "0.14"
ndk-context = "0.1.1"

[build-dependencies]
java-locator = "0.1.8"

[lib]
name = "java_spaghetti_test"
crate-type = ["cdylib"]
path = "lib.rs"

[package.metadata.android]
package = "com.example.java_spaghetti_test"
build_targets = [ "aarch64-linux-android" ]

[package.metadata.android.sdk]
min_sdk_version = 16
target_sdk_version = 30
```

Before the change:

```
02-10 06:36:46.081  3016  3016 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
02-10 06:36:46.081  3016  3016 F DEBUG   : Abort message: 'JNI ERROR (app bug): local reference table overflow (max=16777216)
02-10 06:36:46.081  3016  3016 F DEBUG   : local reference table dump:
02-10 06:36:46.081  3016  3016 F DEBUG   :   Last 10 entries (of 16777216):
02-10 06:36:46.081  3016  3016 F DEBUG   :     16777215: 0x6f4aa250 java.lang.Class<java.lang.Integer>
02-10 06:36:46.081  3016  3016 F DEBUG   :     16777214: 0x6f4aa250 java.lang.Class<java.lang.Integer>
02-10 06:36:46.081  3016  3016 F DEBUG   :     16777213: 0x6f4aa250 java.lang.Class<java.lang.Integer>
...
```

After the change:
```
java_spaghetti_test: java_spaghetti_test: Time elapsed: 17.10836732 s
```

Note: it would be `local reference table overflow (max=512)` on Android 6.0.

### Another change is possible: reduce `DeleteLocalRef` calls by pushing/popping local frames in `VM::get_env`

This seems like a **minor** optimization (<https://github.com/jni-rs/jni-rs/issues/560#issuecomment-2646119522>). Being capable of making this change, I will not achieve it unless you really want me to do so. The disadvantage of this optimization is about the *complexity* of maintaining a *local frame tracker* (stack) and an overall local reference counter in the thread local storage: 

- `VM::get_env` needs to push a "frame" into the tracker stack before executing the closure, and pop a "frame" from that stack after executing the closure, reducing the overall local ref counter by the usage counter for the local frame being popped.
- `Env` wrapper created by `VM::get_env` should keep the corresponding local frame depth (it cannot be transparent) internally, to prevent the use of outer `env` in an inner frame. In callback functions, the `env` pointer passed to the function may be wrapped by an `unsafe` function maintaining the frame tracker just like what `VM::get_env` does.
- Each *item* of the *local frame tracker* needs to store a current local frame capacity worst-case estimation, a local frame usage counter, and a vector (trash can) of `jobject`s coming from dropped `Local`s.
- Every local reference needs to have a corresponding `Local` wrapper; every operation that creates a `Local` wrapper (probably including `from_raw`) needs to increase the frame usage counter of the stack top (as well as the overall usage counter), call `EnsureLocalCapacity` to increase capacity estimation if needed; if the overall counter reaches certain limit, it may even pop some `jobject`s from the "trash can" and call `DeleteLocalRef` for them, then decrease both counters.
- `Local` needs to store its corresponding frame depth too, because a `Local` created in an outer frame may be dropped in an inner frame: push it into the trash can of the correct level in the frame tracker.
