### PR TITLE
Update to cafebabe 0.9.0; fix clippy warnings

### DIFF
--- a/.github/workflows/rust_nightly.yml
+++ b/.github/workflows/rust_nightly.yml
@@ -17,7 +17,10 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update nightly && rustup default nightly
     - run: rustup component add rustfmt
+    - run: rustup component add clippy
     - name: Check fmt
       run: cargo fmt -- --check
+    - name: Clippy
+      run: cargo clippy -- -Dwarnings
     - name: Test
       run: cargo test

--- a/java-spaghetti-gen/Cargo.toml
+++ b/java-spaghetti-gen/Cargo.toml
@@ -9,13 +9,13 @@ categories = ["development-tools::ffi"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cafebabe = "0.8.0"
+cafebabe = "0.9.0"
 clap = { version = "4", features = ["derive"] }
 bitflags = "2.8.0"
 serde = "1.0.197"
 serde_derive = "1.0.197"
 toml = "0.8.10"
-zip = "2.2.2"
+zip = "4.1.0"
 quote = "1.0.40"
 proc-macro2 = "1.0.95"
 anyhow = "1.0.98"

--- a/java-spaghetti-gen/src/config/runtime.rs
+++ b/java-spaghetti-gen/src/config/runtime.rs
@@ -167,7 +167,7 @@ fn expand_vars(string: String) -> String {
             if let Ok(replacement) = std::env::var(segment) {
                 buf.push_str(&replacement[..]);
             } else {
-                println!("cargo:rerun-if-env-changed={}", segment);
+                println!("cargo:rerun-if-env-changed={segment}");
                 buf.push('%');
                 buf.push_str(segment);
                 buf.push('%');

--- a/java-spaghetti-gen/src/emit_rust/class_proxy.rs
+++ b/java-spaghetti-gen/src/emit_rust/class_proxy.rs
@@ -13,6 +13,7 @@ use crate::emit_rust::fields::emit_rust_type;
 use crate::parser_util::Id;
 
 impl Class {
+    #[allow(clippy::vec_init_then_push)]
     pub(crate) fn write_proxy(&self, context: &Context, methods: &[Method]) -> anyhow::Result<TokenStream> {
         let mut emit_reject_reasons = Vec::new();
 
@@ -204,7 +205,7 @@ fn mangle_native_method(path: &str, name: &str, args: &[FieldDescriptor]) -> Str
     let mut res = String::new();
     res.push_str("Java_");
     res.push_str(&mangle_native(path));
-    res.push_str("_");
+    res.push('_');
     res.push_str(&mangle_native(name));
     res.push_str("__");
     for d in args {
@@ -219,7 +220,7 @@ fn mangle_native(s: &str) -> String {
     for c in s.chars() {
         match c {
             '0'..='9' | 'a'..='z' | 'A'..='Z' => res.push(c),
-            '/' => res.push_str("_"),
+            '/' => res.push('_'),
             '_' => res.push_str("_1"),
             ';' => res.push_str("_2"),
             '[' => res.push_str("_3"),

--- a/java-spaghetti-gen/src/emit_rust/class_proxy.rs
+++ b/java-spaghetti-gen/src/emit_rust/class_proxy.rs
@@ -10,7 +10,7 @@ use super::fields::RustTypeFlavor;
 use super::methods::Method;
 use crate::emit_rust::Context;
 use crate::emit_rust::fields::emit_rust_type;
-use crate::parser_util::{Id, emit_field_descriptor};
+use crate::parser_util::Id;
 
 impl Class {
     pub(crate) fn write_proxy(&self, context: &Context, methods: &[Method]) -> anyhow::Result<TokenStream> {
@@ -208,7 +208,7 @@ fn mangle_native_method(path: &str, name: &str, args: &[FieldDescriptor]) -> Str
     res.push_str(&mangle_native(name));
     res.push_str("__");
     for d in args {
-        res.push_str(&mangle_native(&emit_field_descriptor(d)));
+        res.push_str(&mangle_native(&d.to_string()));
     }
 
     res

--- a/java-spaghetti-gen/src/emit_rust/classes.rs
+++ b/java-spaghetti-gen/src/emit_rust/classes.rs
@@ -114,8 +114,8 @@ impl Class {
         };
 
         let docs = match KnownDocsUrl::from_class(context, self.java.path()) {
-            Some(url) => format!("{} {} {}", visibility, keyword, url),
-            None => format!("{} {} {}", visibility, keyword, self.java.path().as_str()),
+            Some(url) => format!("{visibility} {keyword} {url}"),
+            None => format!("{visibility} {keyword} {}", self.java.path().as_str()),
         };
 
         let rust_name = format_ident!("{}", &self.rust.struct_name);
@@ -235,7 +235,7 @@ impl Class {
 
         out.extend(quote!(impl #rust_name { #contents }));
 
-        if context.proxy_included(&self.java.path().as_str()) {
+        if context.proxy_included(self.java.path().as_str()) {
             out.extend(self.write_proxy(context, &methods)?);
         }
 

--- a/java-spaghetti-gen/src/emit_rust/fields.rs
+++ b/java-spaghetti-gen/src/emit_rust/fields.rs
@@ -120,7 +120,7 @@ impl<'a> Field<'a> {
         match self.rust_names.as_ref().map_err(|e| anyhow!("bad mangling: {e}"))? {
             FieldMangling::ConstValue(constant, value) => {
                 let constant = format_ident!("{}", constant);
-                let value = emit_constant(&value, descriptor);
+                let value = emit_constant(value, descriptor);
                 let ty = if descriptor.dimensions == 0
                     && let FieldType::Object(cls) = &descriptor.field_type
                     && Id::from(cls).is_string_class()
@@ -208,14 +208,14 @@ pub fn emit_constant(constant: &LiteralConstant<'_>, descriptor: &FieldDescripto
                 let value = *value as i16;
                 quote!(#value)
             }
-            _ => panic!("invalid constant for char {:?}", constant),
+            _ => panic!("invalid constant for char {constant:?}"),
         };
     }
     if descriptor.field_type == FieldType::Boolean && descriptor.dimensions == 0 {
         return match constant {
             LiteralConstant::Integer(0) => quote!(false),
             LiteralConstant::Integer(1) => quote!(true),
-            _ => panic!("invalid constant for boolean {:?}", constant),
+            _ => panic!("invalid constant for boolean {constant:?}"),
         };
     }
 

--- a/java-spaghetti-gen/src/emit_rust/known_docs_url.rs
+++ b/java-spaghetti-gen/src/emit_rust/known_docs_url.rs
@@ -4,7 +4,7 @@ use cafebabe::descriptors::{FieldDescriptor, FieldType};
 
 use super::methods::Method;
 use crate::emit_rust::Context;
-use crate::parser_util::{Id, IdBuf};
+use crate::parser_util::Id;
 
 pub(crate) struct KnownDocsUrl {
     pub(crate) label: String,
@@ -149,7 +149,7 @@ impl KnownDocsUrl {
                 FieldType::Float => "float",
                 FieldType::Double => "double",
                 FieldType::Object(ref class_name) => {
-                    let class = IdBuf::from(class_name);
+                    let class = Id::from(class_name);
                     obj_arg = class
                         .as_str()
                         .replace('/', pattern.argument_namespace_separator.as_str())

--- a/java-spaghetti-gen/src/emit_rust/methods.rs
+++ b/java-spaghetti-gen/src/emit_rust/methods.rs
@@ -7,7 +7,7 @@ use super::fields::{RustTypeFlavor, emit_fragment_type, emit_rust_type};
 use super::known_docs_url::KnownDocsUrl;
 use crate::emit_rust::Context;
 use crate::identifiers::MethodManglingStyle;
-use crate::parser_util::{JavaClass, JavaMethod, emit_method_descriptor};
+use crate::parser_util::{JavaClass, JavaMethod};
 
 pub struct Method<'a> {
     pub class: &'a JavaClass,
@@ -48,7 +48,7 @@ impl<'a> Method<'a> {
             "{}\x1f{}\x1f{}",
             self.class.path().as_str(),
             self.java.name(),
-            emit_method_descriptor(self.java.descriptor())
+            self.java.descriptor()
         );
 
         let ignored = context.config.ignore_class_methods.contains(&java_class_method)
@@ -162,7 +162,7 @@ impl<'a> Method<'a> {
         };
 
         let java_name = cstring(self.java.name());
-        let descriptor = cstring(&emit_method_descriptor(self.java.descriptor()));
+        let descriptor = cstring(&self.java.descriptor().to_string());
         let method_name = format_ident!("{method_name}");
 
         let call = if self.java.is_constructor() {

--- a/java-spaghetti-gen/src/emit_rust/methods.rs
+++ b/java-spaghetti-gen/src/emit_rust/methods.rs
@@ -147,7 +147,7 @@ impl<'a> Method<'a> {
 
         let docs = match KnownDocsUrl::from_method(context, self) {
             Some(url) => format!("{url}"),
-            None => format!("{}", self.java.name()),
+            None => self.java.name().to_string(),
         };
 
         let throwable = context.throwable_rust_path(mod_);

--- a/java-spaghetti-gen/src/emit_rust/mod.rs
+++ b/java-spaghetti-gen/src/emit_rust/mod.rs
@@ -52,7 +52,7 @@ impl<'a> Context<'a> {
     pub fn java_to_rust_path(&self, java_class: parser_util::Id, mod_: &str) -> Result<TokenStream, Box<dyn Error>> {
         let m = Class::mod_for(self, java_class)?;
         let s = Class::name_for(self, java_class)?;
-        let fqn = format!("{}::{}", m, s);
+        let fqn = format!("{m}::{s}");
 
         // Calculate relative path from B to A.
         let b: Vec<&str> = mod_.split("::").collect();

--- a/java-spaghetti-gen/src/emit_rust/modules.rs
+++ b/java-spaghetti-gen/src/emit_rust/modules.rs
@@ -21,14 +21,14 @@ impl Module {
         for (name, module) in self.modules.iter() {
             writeln!(out)?;
 
-            writeln!(out, "pub mod {} {{", name)?;
+            writeln!(out, "pub mod {name} {{")?;
             module.write(context, out)?;
             writeln!(out, "}}")?;
         }
 
         for (_, class) in self.classes.iter() {
             let res = class.write(context)?;
-            out.write(dumb_format(res).as_bytes())?;
+            out.write_all(dumb_format(res).as_bytes())?;
         }
 
         Ok(())
@@ -61,7 +61,7 @@ struct DumbFormatter {
 
 impl DumbFormatter {
     fn newline(&mut self) {
-        self.f.push_str("\n");
+        self.f.push('\n');
         for _ in 0..self.indent {
             self.f.push_str("    ");
         }
@@ -71,7 +71,7 @@ impl DumbFormatter {
 
     fn pre_write(&mut self) {
         if self.space && !self.after_newline {
-            self.f.push_str(" ");
+            self.f.push(' ');
         }
         self.space = false;
         self.after_newline = false;

--- a/java-spaghetti-gen/src/identifiers/method_mangling_style.rs
+++ b/java-spaghetti-gen/src/identifiers/method_mangling_style.rs
@@ -2,7 +2,7 @@ use cafebabe::descriptors::{FieldType, MethodDescriptor};
 use serde_derive::Deserialize;
 
 use super::rust_identifier::{IdentifierManglingError, javaify_identifier, rustify_identifier};
-use crate::parser_util::{ClassName, IdPart};
+use crate::parser_util::{Id, IdPart};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
@@ -75,7 +75,7 @@ pub enum MethodManglingStyle {
 fn method_mangling_style_mangle_test() {
     use std::borrow::Cow;
 
-    use cafebabe::descriptors::{FieldDescriptor, ReturnDescriptor, UnqualifiedSegment};
+    use cafebabe::descriptors::{ClassName, FieldDescriptor, ReturnDescriptor};
 
     let desc_no_arg_ret_v = MethodDescriptor {
         parameters: Vec::new(),
@@ -93,19 +93,7 @@ fn method_mangling_style_mangle_test() {
     let desc_arg_obj_ret_v = MethodDescriptor {
         parameters: vec![FieldDescriptor {
             dimensions: 0,
-            field_type: FieldType::Object(cafebabe::descriptors::ClassName {
-                segments: vec![
-                    UnqualifiedSegment {
-                        name: Cow::Borrowed("java"),
-                    },
-                    UnqualifiedSegment {
-                        name: Cow::Borrowed("lang"),
-                    },
-                    UnqualifiedSegment {
-                        name: Cow::Borrowed("Object"),
-                    },
-                ],
-            }),
+            field_type: FieldType::Object(ClassName::try_from(Cow::Borrowed("java/lang/Object")).unwrap()),
         }],
         return_type: ReturnDescriptor::Void,
     };
@@ -245,7 +233,7 @@ impl MethodManglingStyle {
                 FieldType::Float => buffer.push_str("_float"),
                 FieldType::Double => buffer.push_str("_double"),
                 FieldType::Object(class_name) => {
-                    let class = ClassName::from(class_name);
+                    let class = Id::from(class_name);
 
                     if long_sig {
                         for component in class.iter() {

--- a/java-spaghetti-gen/src/parser_util/class.rs
+++ b/java-spaghetti-gen/src/parser_util/class.rs
@@ -1,9 +1,9 @@
-use std::borrow::Cow;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
 
 pub use cafebabe::ClassAccessFlags;
 use cafebabe::attributes::AttributeData;
+use cafebabe::descriptors::ClassName;
 
 use super::Id;
 
@@ -79,7 +79,7 @@ impl JavaClass {
         self.get().super_class.as_ref().map(|class| Id(class))
     }
 
-    pub fn interfaces(&self) -> std::slice::Iter<'_, Cow<'_, str>> {
+    pub fn interfaces(&self) -> std::slice::Iter<'_, ClassName<'_>> {
         self.get().interfaces.iter()
     }
 

--- a/java-spaghetti-gen/src/parser_util/field.rs
+++ b/java-spaghetti-gen/src/parser_util/field.rs
@@ -1,11 +1,7 @@
-use std::fmt::Write;
-
 use cafebabe::FieldAccessFlags;
 use cafebabe::attributes::AttributeData;
 use cafebabe::constant_pool::LiteralConstant;
-use cafebabe::descriptors::{FieldDescriptor, FieldType};
-
-use super::ClassName;
+use cafebabe::descriptors::FieldDescriptor;
 
 #[derive(Clone, Copy, Debug)]
 pub struct JavaField<'a> {
@@ -95,30 +91,4 @@ impl<'a> JavaField<'a> {
     pub fn descriptor<'s>(&'s self) -> &'a FieldDescriptor<'a> {
         &self.java.descriptor
     }
-}
-
-pub fn emit_field_descriptor(descriptor: &FieldDescriptor) -> String {
-    let mut res = String::new();
-    for _ in 0..descriptor.dimensions {
-        res.push('[');
-    }
-    if let FieldType::Object(class_name) = &descriptor.field_type {
-        res.push('L');
-        write!(&mut res, "{}", ClassName::from(class_name)).unwrap();
-        res.push(';');
-    } else {
-        let ch = match descriptor.field_type {
-            FieldType::Boolean => 'Z',
-            FieldType::Byte => 'B',
-            FieldType::Char => 'C',
-            FieldType::Short => 'S',
-            FieldType::Integer => 'I',
-            FieldType::Long => 'J',
-            FieldType::Float => 'F',
-            FieldType::Double => 'D',
-            _ => unreachable!(),
-        };
-        res.push(ch)
-    }
-    res
 }

--- a/java-spaghetti-gen/src/parser_util/method.rs
+++ b/java-spaghetti-gen/src/parser_util/method.rs
@@ -1,8 +1,6 @@
 use cafebabe::MethodAccessFlags;
 use cafebabe::attributes::AttributeData;
-use cafebabe::descriptors::{MethodDescriptor, ReturnDescriptor};
-
-use super::emit_field_descriptor;
+use cafebabe::descriptors::MethodDescriptor;
 
 pub struct JavaMethod<'a> {
     java: &'a cafebabe::MethodInfo<'a>,
@@ -100,19 +98,4 @@ impl<'a> JavaMethod<'a> {
     pub fn descriptor<'s>(&'s self) -> &'a MethodDescriptor<'a> {
         &self.java.descriptor
     }
-}
-
-pub fn emit_method_descriptor(descriptor: &MethodDescriptor) -> String {
-    let mut res = String::new();
-    res.push('(');
-    for arg in descriptor.parameters.iter() {
-        res.push_str(&emit_field_descriptor(arg))
-    }
-    res.push(')');
-    if let ReturnDescriptor::Return(desc) = &descriptor.return_type {
-        res.push_str(&emit_field_descriptor(desc))
-    } else {
-        res.push('V')
-    }
-    res
 }

--- a/java-spaghetti-gen/src/parser_util/mod.rs
+++ b/java-spaghetti-gen/src/parser_util/mod.rs
@@ -4,6 +4,6 @@ mod id;
 mod method;
 
 pub use class::JavaClass;
-pub use field::{JavaField, emit_field_descriptor};
+pub use field::JavaField;
 pub use id::*;
-pub use method::{JavaMethod, emit_method_descriptor};
+pub use method::JavaMethod;

--- a/java-spaghetti-gen/src/run/mod.rs
+++ b/java-spaghetti-gen/src/run/mod.rs
@@ -1,5 +1,7 @@
 //! Core generation logic
 
+// XXX: rename this submodule
+#[allow(clippy::module_inception)]
 mod run;
 
 pub use run::run;

--- a/java-spaghetti-gen/src/run/run.rs
+++ b/java-spaghetti-gen/src/run/run.rs
@@ -76,10 +76,7 @@ fn gather_file(context: &mut emit_rust::Context, path: &Path) -> Result<(), Box<
         unknown => {
             Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!(
-                    "Input files must have a '.class' or '.jar' extension, not a '.{}' extension",
-                    unknown
-                ),
+                format!("Input files must have a '.class' or '.jar' extension, not a '.{unknown}' extension",),
             ))?;
         }
     }

--- a/java-spaghetti-gen/src/util/progress.rs
+++ b/java-spaghetti-gen/src/util/progress.rs
@@ -19,7 +19,7 @@ impl Progress {
 
     pub fn force_update(&mut self, msg: &str) {
         self.can_next_log = Instant::now() + self.debounce;
-        println!("{}", msg);
+        println!("{msg}");
     }
 
     pub fn update(&mut self, msg: &str) {

--- a/java-spaghetti/Cargo.toml
+++ b/java-spaghetti/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "java-spaghetti"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 description = "Glue code to accompany the java-spaghetti code generator for binding to JVM APIs from Rust"
 documentation = "https://docs.rs/java-spaghetti/"
 repository = "https://github.com/Dirbaio/java-spaghetti"

--- a/java-spaghetti/src/env.rs
+++ b/java-spaghetti/src/env.rs
@@ -1,8 +1,8 @@
 use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::ptr::{self, null_mut};
-use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicPtr, Ordering};
 
 use jni_sys::*;
 
@@ -69,6 +69,7 @@ pub struct Env<'env> {
 static CLASS_LOADER: AtomicPtr<_jobject> = AtomicPtr::new(null_mut());
 
 #[allow(clippy::missing_safety_doc)]
+#[allow(unsafe_op_in_unsafe_fn)]
 impl<'env> Env<'env> {
     pub unsafe fn from_raw(ptr: *mut JNIEnv) -> Self {
         Self {
@@ -232,7 +233,7 @@ impl<'env> Env<'env> {
         }
 
         // If neither found the class, panic.
-        panic!("couldn't load class {:?}", class);
+        panic!("couldn't load class {class:?}");
     }
 
     unsafe fn require_class_jni(self, class: &CStr) -> jclass {

--- a/java-spaghetti/src/jni_type.rs
+++ b/java-spaghetti/src/jni_type.rs
@@ -4,6 +4,8 @@ use jni_sys::*;
 
 /// JNI bindings rely on this type being accurate.
 ///
+/// # Safety
+///
 /// **unsafe**: Passing the wrong type can cause unsoundness, since the code that interacts with JNI blindly trusts it's correct.
 ///
 /// Why the awkward callback style instead of returning `&'static CStr`?  Arrays of arrays may need to dynamically

--- a/java-spaghetti/src/lib.rs
+++ b/java-spaghetti/src/lib.rs
@@ -62,6 +62,7 @@ pub trait ThrowableType: ReferenceType {}
 
 /// You should generally not be interacting with this type directly, but it must be public for codegen.
 #[doc(hidden)]
+#[warn(clippy::missing_safety_doc)]
 pub unsafe trait ReferenceType: JniType + Sized + 'static {}
 
 /// Marker trait indicating `Self` can be assigned to `T`.

--- a/java-spaghetti/src/refs/arg.rs
+++ b/java-spaghetti/src/refs/arg.rs
@@ -42,7 +42,7 @@ impl<T: ReferenceType> Arg<T> {
         if self.object.is_null() {
             None
         } else {
-            Some(Ref::from_raw(env, self.object))
+            Some(unsafe { Ref::from_raw(env, self.object) })
         }
     }
 
@@ -52,7 +52,7 @@ impl<T: ReferenceType> Arg<T> {
     /// the intended use case of immediately converting any [Arg] into [Local] at the start of a JNI callback,
     /// where Java directly invoked your function with an [Env] + arguments, is sound.
     pub unsafe fn into_local<'env>(self, env: Env<'env>) -> Option<Local<'env, T>> {
-        self.into_ref(env).map(|r| r.as_local())
+        unsafe { self.into_ref(env) }.map(|r| r.as_local())
     }
 
     /// This equals [Arg::into_ref] + [Ref::as_global].
@@ -61,6 +61,6 @@ impl<T: ReferenceType> Arg<T> {
     ///
     /// **unsafe**:  The same as [Arg::into_ref].
     pub unsafe fn into_global(self, env: Env) -> Option<Global<T>> {
-        self.into_ref(env).as_ref().map(Ref::as_global)
+        unsafe { self.into_ref(env) }.as_ref().map(Ref::as_global)
     }
 }

--- a/java-spaghetti/src/refs/local.rs
+++ b/java-spaghetti/src/refs/local.rs
@@ -43,7 +43,7 @@ impl<'env, T: ReferenceType> Local<'env, T> {
     /// - `object` references an instance of type `T`.
     pub unsafe fn from_raw(env: Env<'env>, object: jobject) -> Self {
         Self {
-            ref_: Ref::from_raw(env, object),
+            ref_: unsafe { Ref::from_raw(env, object) },
         }
     }
 

--- a/java-spaghetti/src/refs/ref_.rs
+++ b/java-spaghetti/src/refs/ref_.rs
@@ -88,11 +88,10 @@ impl<'env, T: ReferenceType> Ref<'env, T> {
         let env = self.env();
         let jnienv = env.as_raw();
         let class = U::static_with_jni_type(|t| unsafe { env.require_class(t) });
-        let assignable = unsafe {
-            let ret = ((**jnienv).v1_2.IsInstanceOf)(jnienv, self.as_raw(), class);
+        let assignable = unsafe { ((**jnienv).v1_2.IsInstanceOf)(jnienv, self.as_raw(), class) };
+        unsafe {
             ((**jnienv).v1_2.DeleteLocalRef)(jnienv, class);
-            ret
-        };
+        }
         if assignable { Ok(()) } else { Err(crate::CastError) }
     }
 

--- a/java-spaghetti/src/string_chars.rs
+++ b/java-spaghetti/src/string_chars.rs
@@ -25,8 +25,8 @@ impl<'env> StringChars<'env> {
     pub unsafe fn from_env_jstring(env: Env<'env>, string: jstring) -> Self {
         debug_assert!(!string.is_null());
 
-        let chars = env.get_string_chars(string);
-        let length = env.get_string_length(string);
+        let chars = unsafe { env.get_string_chars(string) };
+        let length = unsafe { env.get_string_length(string) };
 
         Self {
             env,
@@ -42,7 +42,7 @@ impl<'env> StringChars<'env> {
     }
 
     /// [std::char::decode_utf16]\(...\)s these string characters.
-    pub fn decode(&self) -> char::DecodeUtf16<iter::Cloned<slice::Iter<u16>>> {
+    pub fn decode(&self) -> char::DecodeUtf16<iter::Cloned<slice::Iter<'_, u16>>> {
         char::decode_utf16(self.chars().iter().cloned())
     }
 

--- a/java-spaghetti/src/vm.rs
+++ b/java-spaghetti/src/vm.rs
@@ -49,7 +49,7 @@ impl VM {
             JNI_EDETACHED => {
                 let ret = unsafe { ((**self.0).v1_2.AttachCurrentThread)(self.0, &mut env, null_mut()) };
                 if ret != JNI_OK {
-                    panic!("AttachCurrentThread returned unknown error: {}", ret)
+                    panic!("AttachCurrentThread returned unknown error: {ret}")
                 }
                 if !get_thread_exit_flag() {
                     set_thread_attach_flag(self.0);
@@ -57,7 +57,7 @@ impl VM {
                 true
             }
             JNI_EVERSION => panic!("GetEnv returned JNI_EVERSION"),
-            unexpected => panic!("GetEnv returned unknown error: {}", unexpected),
+            unexpected => panic!("GetEnv returned unknown error: {unexpected}"),
         };
 
         let result = callback(unsafe { Env::from_raw(env as _) });


### PR DESCRIPTION
I've done these changes by myself. Output of java-spaghetti-gen remained exactly the same. Thanks for checking!