### PR TITLE
Replace `JniType` with `ReferenceType`; use new types in `Env` and caches; support dynamic class loading for proxies

### DIFF
--- a/java-spaghetti-gen/src/emit/class_proxy.rs
+++ b/java-spaghetti-gen/src/emit/class_proxy.rs
@@ -10,7 +10,6 @@ use super::fields::RustTypeFlavor;
 use super::methods::Method;
 use crate::emit::Context;
 use crate::emit::fields::emit_type;
-use crate::parser_util::Id;
 
 impl Class {
     #[allow(clippy::vec_init_then_push)]
@@ -22,9 +21,6 @@ impl Class {
 
         let rust_name = format_ident!("{}", &self.rust.struct_name);
 
-        let object = context
-            .java_to_rust_path(Id("java/lang/Object"), &self.rust.mod_)
-            .unwrap();
         let throwable = context.throwable_rust_path(&self.rust.mod_);
         let rust_proxy_name = format_ident!("{}Proxy", &self.rust.struct_name);
 
@@ -36,6 +32,7 @@ impl Class {
             self.java.path().as_str().replace("$", "_")
         );
 
+        let mut native_regs = Vec::new();
         for method in methods {
             let Some(rust_name) = method.rust_name() else { continue };
             if method.java.is_static()
@@ -60,6 +57,14 @@ impl Class {
             );
             let native_name = format_ident!("{native_name}");
             let rust_name = format_ident!("{rust_name}");
+
+            let mut native_method_desc = method.java.descriptor().to_string();
+            native_method_desc.insert(1, 'J');
+            native_regs.push((
+                cstring(&format!("native_{}", method.java.name())),
+                cstring(&native_method_desc),
+                native_name.clone(),
+            ));
 
             let ret = match &method.java.descriptor.return_type {
                 ReturnDescriptor::Void => quote!(()),
@@ -157,34 +162,59 @@ impl Class {
             pub fn new_proxy<'env>(
                 env: ::java_spaghetti::Env<'env>,
                 proxy: ::std::sync::Arc<dyn #rust_proxy_name>,
+                proxy_class: ::std::option::Option<::java_spaghetti::JClass>,
             ) -> Result<::java_spaghetti::Local<'env, Self>, ::java_spaghetti::Local<'env, #throwable>> {
-                static __CLASS: ::std::sync::OnceLock<::java_spaghetti::Global<#object>> =
-                    ::std::sync::OnceLock::new();
+                static __CLASS: ::std::sync::OnceLock<::java_spaghetti::JClass> = ::std::sync::OnceLock::new();
                 let __jni_class = __CLASS
                     .get_or_init(|| unsafe {
-                        ::java_spaghetti::Local::from_raw(env, env.require_class(#java_proxy_path),)
-                        .as_global()
-                    })
-                    .as_raw();
+                        let required = env.require_class(#java_proxy_path);
+                        if let Ok(proxy_class) = required {
+                            proxy_class
+                        } else if let Some(proxy_class) = proxy_class {
+                            let bin_name = env.get_class_name(&proxy_class).replace('.', "/");
+                            let expected = #java_proxy_path.to_string_lossy();
+                            if bin_name != expected {
+                                panic!("wrong proxy_class, expected: {}, provided: {}", expected, bin_name)
+                            }
+                            Self::register_proxy_methods(env, &proxy_class);
+                            proxy_class
+                        } else {
+                            panic!("{}", required.unwrap_err())
+                        }
+                    });
 
                 let b = ::std::boxed::Box::new(proxy);
                 let ptr = ::std::boxed::Box::into_raw(b);
 
                 static __METHOD: ::std::sync::OnceLock<::java_spaghetti::JMethodID> = ::std::sync::OnceLock::new();
                 unsafe {
-                    let __jni_args = [::java_spaghetti::sys::jvalue {
+                    let __jni_args = &[::java_spaghetti::sys::jvalue {
                         j: ptr.expose_provenance() as i64,
                     }];
-                    let __jni_method = __METHOD
-                        .get_or_init(|| {
-                            ::java_spaghetti::JMethodID::from_raw(env.require_method(
-                                __jni_class,
-                                c"<init>",
-                                c"(J)V",
-                            ))
-                        })
-                        .as_raw();
-                    env.new_object_a(__jni_class, __jni_method, __jni_args.as_ptr())
+                    let __jni_method = *__METHOD.get_or_init(|| env.require_method(__jni_class, c"<init>", c"(J)V"));
+                    env.new_object_a(__jni_class, __jni_method, __jni_args)
+                }
+            }
+        ));
+
+        let mut register_calls = TokenStream::new();
+        for (native_method_name, descriptor, extern_name) in native_regs {
+            register_calls.extend(quote!(
+                {
+                    let method_name = #native_method_name;
+                    let descriptor = #descriptor;
+                    let fn_ptr = #extern_name as *mut _;
+                    let _ = env.register_native_method(proxy_class, method_name, descriptor, fn_ptr);
+                }
+            ));
+        }
+        contents.extend(quote!(
+            fn register_proxy_methods<'env>(
+                env: ::java_spaghetti::Env<'env>,
+                proxy_class: &::java_spaghetti::JClass,
+            ) {
+                unsafe {
+                    #register_calls
                 }
             }
         ));

--- a/java-spaghetti-gen/src/emit/classes.rs
+++ b/java-spaghetti-gen/src/emit/classes.rs
@@ -103,11 +103,6 @@ impl Class {
 
         let rust_name = format_ident!("{}", &self.rust.struct_name);
 
-        let referencetype_impl = match self.java.is_static() {
-            true => quote!(),
-            false => quote!(unsafe impl ::java_spaghetti::ReferenceType for #rust_name {}),
-        };
-
         let mut out = TokenStream::new();
 
         let java_path = cstring(self.java.path().as_str());
@@ -117,11 +112,13 @@ impl Class {
             #attributes
             #visibility enum #rust_name {}
 
-            #referencetype_impl
-
-            unsafe impl ::java_spaghetti::JniType for #rust_name {
-                fn static_with_jni_type<R>(callback: impl FnOnce(&::std::ffi::CStr) -> R) -> R {
-                    callback(#java_path)
+            unsafe impl ::java_spaghetti::ReferenceType for #rust_name {
+                fn jni_reference_type_name() -> ::std::borrow::Cow<'static, ::std::ffi::CStr> {
+                    ::std::borrow::Cow::Borrowed(#java_path)
+                }
+                unsafe fn jni_class_cache_once_lock() -> &'static ::std::sync::OnceLock<::java_spaghetti::JClass> {
+                    static CLASS_CACHE: ::std::sync::OnceLock<::java_spaghetti::JClass> = ::std::sync::OnceLock::new();
+                    &CLASS_CACHE
                 }
             }
         ));
@@ -146,23 +143,6 @@ impl Class {
         }
 
         let mut contents = TokenStream::new();
-
-        let object = context
-            .java_to_rust_path(Id("java/lang/Object"), &self.rust.mod_)
-            .unwrap();
-
-        let class = cstring(self.java.path().as_str());
-
-        contents.extend(quote!(
-            fn __class_global_ref(__jni_env: ::java_spaghetti::Env) -> ::java_spaghetti::sys::jobject {
-                static __CLASS: ::std::sync::OnceLock<::java_spaghetti::Global<#object>> = ::std::sync::OnceLock::new();
-                __CLASS
-                    .get_or_init(|| unsafe {
-                        ::java_spaghetti::Local::from_raw(__jni_env, __jni_env.require_class(#class)).as_global()
-                    })
-                    .as_raw()
-            }
-        ));
 
         let mut methods: Vec<Method> = self
             .java

--- a/java-spaghetti-gen/src/emit/classes.rs
+++ b/java-spaghetti-gen/src/emit/classes.rs
@@ -117,8 +117,8 @@ impl Class {
                     ::std::borrow::Cow::Borrowed(#java_path)
                 }
                 unsafe fn jni_class_cache_once_lock() -> &'static ::std::sync::OnceLock<::java_spaghetti::JClass> {
-                    static CLASS_CACHE: ::std::sync::OnceLock<::java_spaghetti::JClass> = ::std::sync::OnceLock::new();
-                    &CLASS_CACHE
+                    static __CLASS: ::std::sync::OnceLock<::java_spaghetti::JClass> = ::std::sync::OnceLock::new();
+                    &__CLASS
                 }
             }
         ));

--- a/java-spaghetti-gen/src/emit/fields.rs
+++ b/java-spaghetti-gen/src/emit/fields.rs
@@ -129,7 +129,7 @@ impl<'a> Field<'a> {
                 let set_field = format_ident!("set{static_fragment}_{field_fragment}_field");
 
                 let this_or_class = match self.java.is_static() {
-                    false => quote!(self.as_raw()),
+                    false => quote!(self),
                     true => quote!(__jni_class),
                 };
 
@@ -142,11 +142,12 @@ impl<'a> Field<'a> {
                     #[doc = #get_docs]
                     #attributes
                     pub fn #get<'env>(#env_param) -> #rust_get_type {
+                        use ::java_spaghetti::ReferenceType;
                         static __FIELD: ::std::sync::OnceLock<::java_spaghetti::JFieldID> = ::std::sync::OnceLock::new();
                         #env_let
-                        let __jni_class = Self::__class_global_ref(__jni_env);
+                        let __jni_class = Self::jni_get_class(__jni_env).unwrap();
                         unsafe {
-                            let __jni_field = __FIELD.get_or_init(|| ::java_spaghetti::JFieldID::from_raw(__jni_env.#require_field(__jni_class, #java_name, #descriptor))).as_raw();
+                            let __jni_field = *__FIELD.get_or_init(|| __jni_env.#require_field(__jni_class, #java_name, #descriptor));
                             __jni_env.#get_field(#this_or_class, __jni_field)
                         }
                     }
@@ -164,11 +165,12 @@ impl<'a> Field<'a> {
                         #[doc = #set_docs]
                         #attributes
                         pub fn #set<#lifetimes>(#env_param, value: #rust_set_type) {
+                            use ::java_spaghetti::ReferenceType;
                             static __FIELD: ::std::sync::OnceLock<::java_spaghetti::JFieldID> = ::std::sync::OnceLock::new();
                             #env_let
-                            let __jni_class = Self::__class_global_ref(__jni_env);
+                            let __jni_class = Self::jni_get_class(__jni_env).unwrap();
                             unsafe {
-                                let __jni_field = __FIELD.get_or_init(|| ::java_spaghetti::JFieldID::from_raw(__jni_env.#require_field(__jni_class, #java_name, #descriptor))).as_raw();
+                                let __jni_field = *__FIELD.get_or_init(|| __jni_env.#require_field(__jni_class, #java_name, #descriptor));
                                 __jni_env.#set_field(#this_or_class, __jni_field, value);
                             }
                         }

--- a/java-spaghetti/src/array.rs
+++ b/java-spaghetti/src/array.rs
@@ -110,8 +110,7 @@ macro_rules! primitive_array {
                 let jnienv = env.as_raw();
                 unsafe {
                     let object = ((**jnienv).v1_2.$new_array)(jnienv, size);
-                    let exception = ((**jnienv).v1_2.ExceptionOccurred)(jnienv);
-                    assert!(exception.is_null()); // Only sane exception here is an OOM exception
+                    env.exception_check_raw().expect("OOM");
                     Local::from_raw(env, object)
                 }
             }

--- a/java-spaghetti/src/id_cache.rs
+++ b/java-spaghetti/src/id_cache.rs
@@ -1,16 +1,87 @@
-//! New types for `jfieldID` and `jmethodID` that implement `Send` and `Sync`.
+//! New type for cached class objects as JNI global references; new types for `jfieldID` and `jmethodID` that
+//! implement `Send` and `Sync`.
 //!
 //! Inspired by: <https://docs.rs/jni/0.21.1/jni/objects/struct.JMethodID.html>.
-//!
-//! According to the JNI spec field IDs may be invalidated when the corresponding class is unloaded:
-//! <https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#accessing_fields_and_methods>
-//!
-//! You should generally not be interacting with these types directly, but it must be public for codegen.
 
-use crate::sys::{jfieldID, jmethodID};
+use crate::sys::{jclass, jfieldID, jmethodID, jobject};
+use crate::{Env, VM};
 
-#[doc(hidden)]
+/// New type for cached class objects as JNI global references.
+///
+/// Holding a `JClass` global reference prevents the corresponding Java class from being unloaded.
+#[derive(Debug)]
+pub struct JClass {
+    class: jclass,
+    vm: VM,
+}
+
+unsafe impl Send for JClass {}
+unsafe impl Sync for JClass {}
+
+impl JClass {
+    /// Creates a `JClass` from an owned JNI local reference of a class object and *deletes* the
+    /// local reference.
+    ///
+    /// # Safety
+    ///
+    /// `class` must be a valid JNI local reference to a `java.lang.Class` object.
+    /// Do not use the passed `class` local reference after calling this function.
+    ///
+    /// It is safe to pass the returned value of JNI `FindClass` to it if no exeception occurred.
+    pub unsafe fn from_raw<'env>(env: Env<'env>, class: jclass) -> Self {
+        assert!(!class.is_null(), "from_raw jclass argument is null");
+        let jnienv = env.as_raw();
+        let class_global = unsafe { ((**jnienv).v1_2.NewGlobalRef)(jnienv, class) };
+        unsafe { ((**jnienv).v1_2.DeleteLocalRef)(jnienv, class) }
+        unsafe { Self::from_raw_global(env.vm(), class_global) }
+    }
+
+    /// Wraps an owned raw JNI global reference of a class object.
+    ///
+    /// # Safety
+    ///
+    /// `class` must be a valid JNI global reference to a `java.lang.Class` object.
+    pub unsafe fn from_raw_global(vm: VM, class: jobject) -> Self {
+        assert!(!class.is_null(), "from_raw_global jclass argument is null");
+        Self {
+            class: class as jclass,
+            vm,
+        }
+    }
+
+    pub fn as_raw(&self) -> jclass {
+        self.class
+    }
+}
+
+impl Clone for JClass {
+    fn clone(&self) -> Self {
+        self.vm.with_env(|env| {
+            let env = env.as_raw();
+            let class_global = unsafe { ((**env).v1_2.NewGlobalRef)(env, self.class) };
+            assert!(!class_global.is_null());
+            unsafe { Self::from_raw_global(self.vm, class_global) }
+        })
+    }
+}
+
+// XXX: Unfortunately, static items (e.g. `OnceLock`) may not call drop() at the end of the Rust program:
+// JNI global references may be leaked if `java-spaghetti`-based libraries are unloaded and reloaded by the VM.
+impl Drop for JClass {
+    fn drop(&mut self) {
+        self.vm.with_env(|env| {
+            let env = env.as_raw();
+            unsafe { ((**env).v1_2.DeleteGlobalRef)(env, self.class) }
+        });
+    }
+}
+
+/// New type for `jfieldID`, implements `Send` and `Sync`.
+///
+/// According to the JNI spec, field IDs may be invalidated when the corresponding class is unloaded:
+/// <https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#accessing_fields_and_methods>.
 #[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
 pub struct JFieldID {
     internal: jfieldID,
 }
@@ -20,13 +91,13 @@ unsafe impl Send for JFieldID {}
 unsafe impl Sync for JFieldID {}
 
 impl JFieldID {
-    /// Creates a [`JFieldID`] that wraps the given `raw` [`jfieldID`].
+    /// Creates a [`JFieldID`] that wraps the given raw [`jfieldID`].
     ///
     /// # Safety
     ///
-    /// Expects a valid, non-`null` ID.
+    /// Expects a valid, non-null ID.
     pub unsafe fn from_raw(raw: jfieldID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw fieldID argument");
+        assert!(!raw.is_null(), "from_raw jfieldID argument is null");
         Self { internal: raw }
     }
 
@@ -35,8 +106,12 @@ impl JFieldID {
     }
 }
 
-#[doc(hidden)]
+/// New type for `jmethodID`, implements `Send` and `Sync`.
+///
+/// According to the JNI spec, method IDs may be invalidated when the corresponding class is unloaded:
+/// <https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/design.html#accessing_fields_and_methods>.
 #[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
 pub struct JMethodID {
     internal: jmethodID,
 }
@@ -50,9 +125,9 @@ impl JMethodID {
     ///
     /// # Safety
     ///
-    /// Expects a valid, non-`null` ID.
+    /// Expects a valid, non-null ID.
     pub unsafe fn from_raw(raw: jmethodID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+        assert!(!raw.is_null(), "from_raw jmethodID argument is null");
         Self { internal: raw }
     }
 

--- a/java-spaghetti/src/id_cache.rs
+++ b/java-spaghetti/src/id_cache.rs
@@ -49,8 +49,16 @@ impl JClass {
         }
     }
 
+    /// Returns the raw JNI reference pointer.
     pub fn as_raw(&self) -> jclass {
         self.class
+    }
+
+    /// Turns it into a raw global reference; prevents `DeleteGlobalRef` from being called on dropping.
+    pub fn into_raw(self) -> jclass {
+        let class = self.class;
+        std::mem::forget(self); // Don't delete the object.
+        class
     }
 }
 

--- a/java-spaghetti/src/refs/ref_.rs
+++ b/java-spaghetti/src/refs/ref_.rs
@@ -198,10 +198,7 @@ impl<'env, T: ReferenceType> Drop for Monitor<'env, T> {
         let jnienv = env.as_raw();
         let result = unsafe { ((**jnienv).v1_2.MonitorExit)(jnienv, self.inner.as_raw()) };
         assert!(result == jni_sys::JNI_OK);
-        let exception = unsafe { ((**jnienv).v1_2.ExceptionOccurred)(jnienv) };
-        assert!(
-            exception.is_null(),
-            "exception happened calling JNI MonitorExit, the monitor is probably broken previously"
-        );
+        env.exception_check_raw()
+            .expect("exception happened calling JNI MonitorExit, the monitor is probably broken previously");
     }
 }

--- a/java-spaghetti/src/refs/ref_.rs
+++ b/java-spaghetti/src/refs/ref_.rs
@@ -87,11 +87,8 @@ impl<'env, T: ReferenceType> Ref<'env, T> {
     pub(crate) fn check_assignable<U: ReferenceType>(&self) -> Result<(), crate::CastError> {
         let env = self.env();
         let jnienv = env.as_raw();
-        let class = U::static_with_jni_type(|t| unsafe { env.require_class(t) });
+        let class = U::jni_get_class(env).unwrap().as_raw();
         let assignable = unsafe { ((**jnienv).v1_2.IsInstanceOf)(jnienv, self.as_raw(), class) };
-        unsafe {
-            ((**jnienv).v1_2.DeleteLocalRef)(jnienv, class);
-        }
         if assignable { Ok(()) } else { Err(crate::CastError) }
     }
 

--- a/java-spaghetti/src/string_chars.rs
+++ b/java-spaghetti/src/string_chars.rs
@@ -28,6 +28,8 @@ impl<'env> StringChars<'env> {
         let chars = unsafe { env.get_string_chars(string) };
         let length = unsafe { env.get_string_length(string) };
 
+        debug_assert!(!chars.is_null() || length == 0);
+
         Self {
             env,
             string,


### PR DESCRIPTION
- Use macros for `Env` methods: this doesn't change any behavior.
- Simplify exception checking in `Env` methods: reduced some redundant code, however `Env::get_class_name` probably becomes a bit less strong.
- Replace `JniType` with `ReferenceType`; use new types in `Env` and caches: this is the major breaking change. Generated class bindings now implement `ReferenceType` but not `JniType`. Generated JNI type names for multi-dimension arrays changed from `[L[I;`, `[L[Ljava/lang/String;;` to `[[I`, `[[Ljava/lang/String;`. `JClass` are added for class caches. `JClass`, `JMethodID` and `JFieldID` are made public to be used in `Env` methods.
- Make proxy generation working again: this also makes it compatible with the runtime class loading "technique".

<details>
<summary>Trying to test `bluest` here</summary>

Based on <https://github.com/akiles-dev/bluest/commit/3c55517d332b233bc47d969c7c8af2faf132e010>.

Added in `java-spaghetti.yaml`:

```yaml
      - java/lang/ClassLoader
      - java/nio/Buffer
      - java/nio/ByteBuffer
      - dalvik/system/InMemoryDexClassLoader
      - dalvik/system/DexClassLoader
      - dalvik/system/BaseDexClassLoader
```

Added `build.rs`:

```rust
use std::env;
use std::path::PathBuf;

use android_build::{Dexer, JavaBuild};

fn main() {
    if !env::var("TARGET").unwrap().contains("android") {
        return;
    }

    let java_srcs = [
        "src/android/java/android/bluetooth/BluetoothGattCallback.java",
        "src/android/java/android/bluetooth/le/ScanCallback.java",
    ];

    let out_dir: PathBuf = env::var_os("OUT_DIR").unwrap().into();
    let out_class_dir = out_dir.join("java");

    if out_class_dir.try_exists().unwrap_or(false) {
        let _ = std::fs::remove_dir_all(&out_class_dir);
    }
    std::fs::create_dir_all(&out_class_dir)
        .unwrap_or_else(|e| panic!("Cannot create output directory {out_class_dir:?} - {e}"));

    let android_jar = android_build::android_jar(None).expect("No Android platforms found");

    // Compile the Java file into .class files
    let o = JavaBuild::new()
        .files(&java_srcs)
        .class_path(&android_jar)
        .classes_out_dir(&out_class_dir)
        .java_source_version(8)
        .java_target_version(8)
        .command()
        .unwrap_or_else(|e| panic!("Could not generate the java compiler command: {e}"))
        .args(["-encoding", "UTF-8"])
        .output()
        .unwrap_or_else(|e| panic!("Could not run the java compiler: {e}"));

    if !o.status.success() {
        panic!("Java compilation failed: {}", String::from_utf8_lossy(&o.stderr));
    }

    let o = Dexer::new()
        .android_jar(&android_jar)
        .class_path(&out_class_dir)
        .collect_classes(&out_class_dir)
        .unwrap()
        .android_min_api(20) // disable multidex for single dex file output
        .out_dir(out_dir)
        .command()
        .unwrap_or_else(|e| panic!("Could not generate the D8 command: {e}"))
        .output()
        .unwrap_or_else(|e| panic!("Error running D8: {e}"));

    if !o.status.success() {
        panic!("Dex conversion failed: {}", String::from_utf8_lossy(&o.stderr));
    }

    for java_src in java_srcs {
        println!("cargo:rerun-if-changed={java_src}");
    }
}
```

Changed `android/adapter.rs`:

```rust
use std::collections::HashMap;
use std::sync::{Arc, OnceLock};

use async_channel::Sender;
use futures_core::Stream;
use futures_lite::{stream, StreamExt};
use java_spaghetti::{ByteArray, Env, Global, Local, Null, PrimitiveArray, Ref, VM};
use tracing::{debug, warn};
use uuid::Uuid;

use super::bindings::android::bluetooth::le::{
    BluetoothLeScanner, ScanCallback, ScanResult, ScanSettings, ScanSettings_Builder,
};
use super::bindings::android::bluetooth::{BluetoothAdapter, BluetoothGattCallback, BluetoothManager};
use super::bindings::android::content::Context;
use super::bindings::android::os::ParcelUuid;
use super::bindings::java::nio;
use super::bindings::java::lang::{Class, ClassLoader, String as JString};
use super::bindings::java::util::Map_Entry;
use super::device::DeviceImpl;
use super::{JavaIterator, OptionExt};
use super::bindings::dalvik::system::InMemoryDexClassLoader;
use super::bindings::android::bluetooth::{
    BluetoothGatt, BluetoothGattCharacteristic, BluetoothGattDescriptor,
};
use crate::error::ErrorKind;
use crate::util::defer;
use crate::{
    AdapterEvent, AdvertisementData, AdvertisingDevice, ConnectionEvent, Device, DeviceId, Error, ManufacturerData,
    Result,
};

const DEX_DATA: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/classes.dex"));
static CLASS_LOADER: OnceLock<Global<ClassLoader>> = OnceLock::new();

fn init_class_loader(vm: VM, context: &Global<Context>) -> &'static Global<ClassLoader> {
    CLASS_LOADER.get_or_init(|| {
        vm.with_env(|env| {
            let context = context.as_ref(env);
            let context_loader = context.getClassLoader().unwrap();
            // Safety: casts `&[u8]` to `&[i8]`.
            let data = unsafe { std::slice::from_raw_parts(DEX_DATA.as_ptr() as *const i8, DEX_DATA.len()) };
            let byte_array = java_spaghetti::ByteArray::new_from(env, data);
            let dex_buffer = nio::ByteBuffer::wrap_byte_array(env, byte_array).unwrap();
            let dex_loader =
                InMemoryDexClassLoader::new_ByteBuffer_ClassLoader(env, dex_buffer, context_loader).unwrap();
            dex_loader.upcast::<ClassLoader>().as_global()
        })
    })
}

struct AdapterInner {
    context: Global<Context>,
    manager: Global<BluetoothManager>,
    adapter: Global<BluetoothAdapter>,
    le_scanner: Global<BluetoothLeScanner>,
}

#[derive(Clone)]
pub struct AdapterImpl {
    inner: Arc<AdapterInner>,
}

/// Creates an interface to the default Bluetooth adapter for the system.
///
/// # Safety
///
/// - The `Adapter` takes ownership of the global reference and will delete it with the `DeleteGlobalRef` JNI call when dropped. You must not do that yourself.
pub struct AdapterConfig {
    /// - `vm` must be a valid JNI `JavaVM` pointer to a VM that will stay alive for the entire duration the `Adapter` or any structs obtained from it are live.
    vm: *mut java_spaghetti::sys::JavaVM,
    /// - `context` must be a valid global reference to an `android.bluetooth.BluetoothManager` instance, from the `java_vm` VM.
    context: java_spaghetti::sys::jobject,
}

impl AdapterConfig {
    /// Creates a config for the default Bluetooth adapter for the system.
    ///
    /// # Safety
    ///
    /// - `java_vm` must be a valid JNI `JavaVM` pointer to a VM that will stay alive for the entire duration the `Adapter` or any structs obtained from it are live.
    /// - `context` must be a valid global reference to an `android.bluetooth.BluetoothManager` instance, from the `java_vm` VM.
    /// - The `Adapter` takes ownership of the global reference and will delete it with the `DeleteGlobalRef` JNI call when dropped. You must not do that yourself.
    pub unsafe fn new(java_vm: *mut java_spaghetti::sys::JavaVM, context: java_spaghetti::sys::jobject) -> Self {
        Self { vm: java_vm, context }
    }
}

impl AdapterImpl {
    /// Creates an interface to the default Bluetooth adapter for the system.
    ///
    /// # Safety
    ///
    /// In the config object:
    ///
    /// - `vm` must be a valid JNI `JavaVM` pointer to a VM that will stay alive for the entire duration the `Adapter` or any structs obtained from it are live.
    /// - `context` must be a valid global reference to an `android.bluetooth.BluetoothManager` instance, from the `java_vm` VM.
    /// - The `Adapter` takes ownership of the global reference and will delete it with the `DeleteGlobalRef` JNI call when dropped. You must not do that yourself.
    pub async fn with_config(config: AdapterConfig) -> Result<Self> {
        let vm = unsafe { VM::from_raw(config.vm) };
        let context: Global<Context> = unsafe { Global::from_raw(vm, config.context) };
        let _ = init_class_loader(vm, &context);

        vm.with_env(|env| {
            let context = context.as_local(env);
            let class: Global<Class> = unsafe {
                let jclass = env.require_class(c"android/bluetooth/BluetoothManager").unwrap();
                Global::from_raw(vm, jclass.into_raw())
            };
            let manager: Local<BluetoothManager> =
                context.getSystemService_Class(class.as_ref(env)).unwrap().unwrap().cast().unwrap();

            let adapter = manager.getAdapter()?.non_null()?;
            let le_scanner = adapter.getBluetoothLeScanner()?.non_null()?;

            Ok(Self {
                inner: Arc::new(AdapterInner {
                    context: context.as_global(),
                    adapter: adapter.as_global(),
                    le_scanner: le_scanner.as_global(),
                    manager: manager.as_global(),
                }),
            })
        })
    }

    pub(crate) async fn events(&self) -> Result<impl Stream<Item = Result<AdapterEvent>> + Send + Unpin + '_> {
        Ok(stream::empty()) // TODO
    }

    pub async fn wait_available(&self) -> Result<()> {
        Ok(())
    }

    /// Check if the adapter is available
    pub async fn is_available(&self) -> Result<bool> {
        self.inner.adapter.vm().with_env(|env| {
            let adapter = self.inner.adapter.as_local(env);
            adapter
                .isEnabled()
                .map_err(|e| Error::new(ErrorKind::Internal, None, format!("isEnabled threw: {e:?}")))
        })
    }

    pub async fn open_device(&self, id: &DeviceId) -> Result<Device> {
        self.inner.adapter.vm().with_env(|env| {
            let adapter = self.inner.adapter.as_local(env);
            let device = adapter
                .getRemoteDevice_String(JString::from_env_str(env, &id.0))
                .map_err(|e| Error::new(ErrorKind::Internal, None, format!("getRemoteDevice threw: {e:?}")))?
                .non_null()?;
            Ok(Device(DeviceImpl {
                id: id.clone(),
                device: device.as_global(),
            }))
        })
    }

    pub async fn connected_devices(&self) -> Result<Vec<Device>> {
        todo!()
    }

    pub async fn connected_devices_with_services(&self, _services: &[Uuid]) -> Result<Vec<Device>> {
        todo!()
    }

    pub async fn scan<'a>(
        &'a self,
        _services: &'a [Uuid],
    ) -> Result<impl Stream<Item = AdvertisingDevice> + Send + Unpin + 'a> {
        let (start_receiver, stream) = self.inner.manager.vm().with_env(|env| {
            let (start_sender, start_receiver) = async_channel::bounded(1);
            let (device_sender, device_receiver) = async_channel::bounded(16);

            let class_loader = CLASS_LOADER.get().unwrap().as_ref(env);
            let callback = ScanCallback::new_proxy(
                env,
                Arc::new(ScanCallbackProxy {
                    device_sender,
                    start_sender,
                }),
                class_loader.loadClass(
                    &JString::from_env_str(
                        env,
                        "com.github.alexmoon.bluest.proxy.android.bluetooth.le.ScanCallback"
                    )
                )?
                .map(|cls| java_spaghetti::JClass::from_ref(&cls).unwrap())
            )?;

            let callback_global = callback.as_global();
            let scanner = self.inner.le_scanner.as_ref(env);
            let settings = ScanSettings_Builder::new(env)?;
            settings.setScanMode(ScanSettings::SCAN_MODE_LOW_LATENCY)?;
            let settings = settings.build()?.non_null()?;
            scanner.startScan_List_ScanSettings_ScanCallback(Null, settings, callback)?;

            let guard = defer(move || {
                self.inner.manager.vm().with_env(|env| {
                    let callback = callback_global.as_ref(env);
                    let scanner = self.inner.le_scanner.as_ref(env);
                    match scanner.stopScan_ScanCallback(callback) {
                        Ok(()) => debug!("stopped scan"),
                        Err(e) => warn!("failed to stop scan: {:?}", e),
                    };
                });
            });

            Ok::<_, crate::Error>((
                start_receiver,
                Box::pin(device_receiver).map(move |x| {
                    let _guard = &guard;
                    x
                }),
            ))
        })?;

        // Wait for scan started or failed.
        match start_receiver.recv().await {
            Ok(Ok(())) => Ok(stream),
            Ok(Err(e)) => Err(e),
            Err(e) => Err(Error::new(
                ErrorKind::Internal,
                None,
                format!("receiving failed while waiting for start: {e:?}"),
            )),
        }
    }

    pub async fn discover_devices<'a>(
        &'a self,
        services: &'a [Uuid],
    ) -> Result<impl Stream<Item = Result<Device>> + Send + Unpin + 'a> {
        let connected = stream::iter(self.connected_devices_with_services(services).await?).map(Ok);

        // try_unfold is used to ensure we do not start scanning until the connected devices have been consumed
        let advertising = Box::pin(stream::try_unfold(None, |state| async {
            let mut stream = match state {
                Some(stream) => stream,
                None => self.scan(services).await?,
            };
            Ok(stream.next().await.map(|x| (x.device, Some(stream))))
        }));

        Ok(connected.chain(advertising))
    }

    pub async fn connect_device(&self, device: &Device) -> Result<()> {
        self.inner.adapter.vm().with_env(|env| {
            let device = device.0.device.as_local(env);

            let class_loader = CLASS_LOADER.get().unwrap().as_ref(env);
            let callback = BluetoothGattCallback::new_proxy(
                env,
                Arc::new(BluetoothGattCallbackProxy),
                class_loader.loadClass(
                    &JString::from_env_str(
                        env,
                        "com.github.alexmoon.bluest.proxy.android.bluetooth.BluetoothGattCallback"
                    )
                )?
                .map(|cls| java_spaghetti::JClass::from_ref(&cls).unwrap())
            )?;
            device
                .connectGatt_Context_boolean_BluetoothGattCallback(&self.inner.context, false, callback)
                .map_err(|e| Error::new(ErrorKind::Internal, None, format!("connectGatt threw: {e:?}")))?
                .non_null()?;

            Ok(())
        })
    }

// code below is unchanged ------------------------------------------------
```

`bluest-test`'s `Cargo.toml`:

```toml
[workspace]

[package]
name = "bluest-test"
version = "0.1.0"
edition = "2024"
publish = false

[dependencies]
bluest = { path = "../bluest", features = ["unstable"] }
tracing = "0.1.36"
tracing-subscriber = "0.3.15"
# android-activity uses `log`
log = "0.4"
tracing-log = "0.2.0"
ndk-context = "0.1.1"
android-activity = { version = "0.6", features = ["native-activity"] }
futures-lite = "1.13.0"
async-channel = "2.2.0"

[lib]
crate-type = ["cdylib"]

[package.metadata.android]
package = "com.example.bluest_test"
build_targets = ["aarch64-linux-android"]

[package.metadata.android.sdk]
min_sdk_version = 23
target_sdk_version = 30

[[package.metadata.android.uses_feature]]
name = "android.hardware.bluetooth"
required = true

# TODO: support Android 12 and above, which require runtime permissions.
# <https://developer.android.google.cn/develop/connectivity/bluetooth/bt-permissions>
# <https://github.com/rust-mobile/cargo-apk/pull/72>

[[package.metadata.android.uses_permission]]
name = "android.permission.ACCESS_FINE_LOCATION"
max_sdk_version = 30

[[package.metadata.android.uses_permission]]
name = "android.permission.ACCESS_COARSE_LOCATION"
max_sdk_version = 30

[[package.metadata.android.uses_permission]]
name = "android.permission.BLUETOOTH"
max_sdk_version = 30

[[package.metadata.android.uses_permission]]
name = "android.permission.BLUETOOTH_ADMIN"
max_sdk_version = 30
```

`bluest-test`'s `lib.rs`:

```rust
// TODO: create a simple UI with Slint.

use android_activity::{AndroidApp, MainEvent, PollEvent};
use futures_lite::{FutureExt, StreamExt};
use tracing::info;

#[unsafe(no_mangle)]
fn android_main(app: AndroidApp) {
    // android_logger::init_once(
    //     android_logger::Config::default()
    //         .with_max_level(log::LevelFilter::Info)
    //         .with_tag("bluest_test".as_bytes()),
    // );
    let subscriber = tracing_subscriber::FmtSubscriber::builder().without_time().finish();
    tracing::subscriber::set_global_default(subscriber).expect("setting tracing default failed");
    tracing_log::LogTracer::init().expect("setting log tracer failed");

    let (tx, rx) = async_channel::unbounded();
    std::thread::spawn(move || {
        let res = futures_lite::future::block_on(async_main().or(async {
            let _ = rx.recv().await;
            info!("async thread received stop signal.....");
            Ok(())
        }));
        if let Err(e) = res {
            info!("async thread's `block_on` received error {e}.");
        } else {
            info!("async thread terminates itself after it received stop signal.");
        }
    });

    let mut on_destroy = false;
    loop {
        app.poll_events(None, |event| match event {
            PollEvent::Main(MainEvent::Stop) => {
                info!("Main Stop Event.");
                let _ = tx.send(());
            }
            PollEvent::Main(MainEvent::Destroy) => {
                on_destroy = true;
            }
            _ => (),
        });
        if on_destroy {
            return;
        }
    }
}

async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
    let ndk_ctx = ndk_context::android_context();
    let adapter = bluest::Adapter::with_config(unsafe {
        bluest::AdapterConfig::new(ndk_ctx.vm().cast(), ndk_ctx.context().cast())
    })
    .await?;
    adapter.wait_available().await?;

    info!("starting scan...");
    let mut scan = adapter.scan(&[]).await?;
    info!("scan started.");
    while let Some(discovered) = scan.next().await {
        info!("found a device...");
        info!("{:?}", discovered);
    }

    info!("async thread terminates itself.");
    Ok(())
}
```

</details>
